### PR TITLE
Add packed range MPI communication 

### DIFF
--- a/include/userobjects/MyTRIMRasterizer.h
+++ b/include/userobjects/MyTRIMRasterizer.h
@@ -69,10 +69,15 @@ public:
   };
 
 protected:
+  ///@{ pack/unpack the _material_map and _pka_list data into a structure suitable for parallel communication
+  void serialize(std::string & serialized_buffer);
+  void deserialize(std::vector<std::string> & serialized_buffers);
+  ///@}
+
   /// number of coupled variables to map
   const unsigned int _nvars;
 
-  // dimension of the mesh
+  /// dimension of the mesh
   const unsigned int _dim;
 
   ///@{ Element data

--- a/include/userobjects/MyTRIMRun.h
+++ b/include/userobjects/MyTRIMRun.h
@@ -44,6 +44,11 @@ public:
   unsigned int nVars() const { return _nvars; }
 
 protected:
+  ///@{ pack/unpack the _result_map into a structure suitable for parallel communication
+  void serialize(std::string & serialized_buffer);
+  void deserialize(std::vector<std::string> & serialized_buffers);
+  ///@}
+
   /// data such as interstitials and vacancies produced will be stored here
   MyTRIMResultMap _result_map;
 
@@ -51,7 +56,7 @@ protected:
   const MyTRIMRasterizer & _rasterizer;
 
   /// number of elements in the TRIM simulation
-  int _nvars;
+  const unsigned int _nvars;
 
   /// number of primary knock-on atoms (PKA) to simulate
   const std::vector<MyTRIM_NS::IonBase> & _pka_list;


### PR DESCRIPTION
Uses the new packed range communication capabilities to add MPI communication of complex structures in `MyTRIMRasterizer` and `MyTRIMRun`. This required custom specializations of `dataLoad` and `dataStore`; one for a struct containing an std::vector and one for a class with a vtable pointer (in both cases simply serializing the memory occupied by the structure does not work. for the first object the std::vector holds data on the heap, and for the second structure deserializing will overwrite the vtable pointer, which will make the call to the destructor segfault).

Closes #12 
