### PR TITLE
Add PDF Base class

### DIFF
--- a/include/utils/ProbabilityDensityFunctionBase.h
+++ b/include/utils/ProbabilityDensityFunctionBase.h
@@ -1,0 +1,27 @@
+#ifndef PROBABILITYDENSITYFUNCTIONBASE_H
+#define PROBABILITYDENSITYFUNCTIONBASE_H
+
+#include "Moose.h"
+#include "RandomInterface.h"
+
+template<class T>
+class ProbabilityDensityFunctionBase
+{
+public:
+  ProbabilityDensityFunctionBase(Real magnitude = 1.0) :
+    _magnitude(magnitude)
+  {
+  }
+
+  /**
+   * Override this function for implementing the
+   * desired sampling behavior
+   */
+  virtual T drawSample() = 0;
+
+protected:
+  /// Magnitude to allow scaling with other PDFs
+  Real _magnitude;
+};
+
+#endif //PROBABILITYDENSITYFUNCTIONBASE_H


### PR DESCRIPTION
I want to create `DiscreteProbabilityDensityFunction` inheriting from `ProbabilityDensityFunctionBase`.
In this case `T` would be of type `std::vector<T>`. 
Should I inherit from `PDFBase` first and then do a template specialization?    
