### PR TITLE
NeutronicsSpectrumSamplerBase doesn't compile when RSN present

### DIFF
--- a/src/userobjects/NeutronicsSpectrumSamplerBase.C
+++ b/src/userobjects/NeutronicsSpectrumSamplerBase.C
@@ -51,7 +51,7 @@ NeutronicsSpectrumSamplerBase::NeutronicsSpectrumSamplerBase(const InputParamete
     // check if isotope names are valid, NOTE: error handling is delegated to Yakxs::Utilities
     YAKXS::Utility::getAZFromIsotopeName(_target_isotope_names[i], A, Z);
     // convert from name to ZAID
-    _zaids[i] = stringToZaid(_target_isotope_names[i]);
+    _zaids[i] = YAKXS::Utility::stringToZaid(_target_isotope_names[i]);
 #else
     _zaids[i] = localStringToZaid(_target_isotope_names[i]);
 #endif


### PR DESCRIPTION
Missing namespace when calling stringToZaid. Undetected because we haven't compiled with RSN before. (#125)
