### PR TITLE
Allow marmot to compile with magpie.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ include $(MOOSE_DIR)/modules/modules.mk
 
 # dep apps
 APPLICATION_DIR    := $(CURDIR)
+MAGPIE_DIR         := $(CURDIR)
 APPLICATION_NAME   := magpie
 BUILD_EXEC         := yes
 DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))

--- a/contrib/gsl.mk
+++ b/contrib/gsl.mk
@@ -1,7 +1,7 @@
 ###############################################################################
 ######################## GNU Scientific Library (GSL) #########################
 ###############################################################################
-GSL_DIR ?= $(realpath $(APPLICATION_DIR)/contrib/gsl)
+GSL_DIR ?= $(realpath $(MAGPIE_DIR)/contrib/gsl)
 
 # check if gsl submodule is checked out
 ifeq ($(wildcard $(GSL_DIR)/Makefile.am),)

--- a/magpie.mk
+++ b/magpie.mk
@@ -2,18 +2,18 @@
 # Check the existence of the contrib submodules and build accordingly
 #
 
-SPPARKS_DIR    ?= $(APPLICATION_DIR)/contrib/spparks
+SPPARKS_DIR    ?= $(MAGPIE_DIR)/contrib/spparks
 ifneq ($(wildcard $(SPPARKS_DIR)/src/Makefile),)
   ADDITIONAL_CPPFLAGS += -DSPPARKS_ENABLED
   app_INCLUDES   += -I $(SPPARKS_DIR)/..
-  include $(APPLICATION_DIR)/contrib/spparks.mk
+  include $(MAGPIE_DIR)/contrib/spparks.mk
 endif
 
-MYTRIM_DIR    ?= $(APPLICATION_DIR)/contrib/mytrim
+MYTRIM_DIR    ?= $(MAGPIE_DIR)/contrib/mytrim
 ifneq ($(wildcard $(MYTRIM_DIR)/trim.h),)
   ADDITIONAL_CPPFLAGS += -DMYTRIM_ENABLED
   app_INCLUDES   += -I $(MYTRIM_DIR)/..
-  include $(APPLICATION_DIR)/contrib/mytrim.mk
+  include $(MAGPIE_DIR)/contrib/mytrim.mk
 endif
 
-include $(APPLICATION_DIR)/contrib/gsl.mk
+include $(MAGPIE_DIR)/contrib/gsl.mk

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -12,6 +12,7 @@ MOOSE_DIR          ?= $(shell dirname `pwd`)/../moose
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 ###############################################################################
 CURRENT_DIR        := $(shell pwd)
+MAGPIE_DIR         := $(CURRENT_DIR)/..
 
 # framework
 include $(FRAMEWORK_DIR)/build.mk


### PR DESCRIPTION
I was trying to get marmot working with magpie and ran into some problems.

Without the `GSL_DIR` in `magpie.mk`, I got a weird empty include "-I" which screwed up the next include path, causing compile failures in marmot.

Without using `MAGPIE_DIR` instead of `APPLICATION_DIR` in `magpie.mk`, when linking marmot it seemed to try to link gsl from `marmot/contrib/gsl`

These changes allowed me to build marmot with magpie. I didn't see any obvious tests in marmot that tests if it worked though.

Is there any interest in providing (possibly optional) tests to either magpie or marmot that tests this configuration?