### PR TITLE
Energy group ordering and unit must be consistent in NeutronicSamplers

### DIFF
--- a/src/userobjects/NeutronicsSpectrumSamplerBase.C
+++ b/src/userobjects/NeutronicsSpectrumSamplerBase.C
@@ -16,7 +16,8 @@ InputParameters validParams<NeutronicsSpectrumSamplerBase>()
   InputParameters params = validParams<ElementUserObject>();
   params.addRequiredParam<std::vector<std::string> >("target_isotope_names", "The list of target isotope names e.g. U235.");
   params.addRequiredCoupledVar("number_densities", "Number densities for each isotope.");
-  params.addRequiredParam<std::vector<Real> >("energy_group_boundaries", "The energy group boundaries in units of MeV.");
+  params.addRequiredParam<std::vector<Real> >("energy_group_boundaries", "The energy group boundaries in units of eV orderd "
+                                                                         "from high to low [natural neutronics ordering].");
   params.addRequiredParam<unsigned int>("L", "The maximum order of Legendre terms for expanding the recoil XS in mu_lab.");
   params.addRequiredParam<std::vector<Point> >("points", "The points where you want to evaluate the variables");
   params.addClassDescription("Radiation Damage user object base class.\n Computes PDFs from neutronics calculations that are used to sample PKAs in BCMC simulations.");
@@ -59,6 +60,13 @@ NeutronicsSpectrumSamplerBase::NeutronicsSpectrumSamplerBase(const InputParamete
 
   _owner.resize(_npoints);
   _qp_cache.resize(_npoints);
+
+  // check energy group ordering
+  if (_energy_group_boundaries.size() < 2)
+    mooseError("At least 2 boundaries must be provided for energy_group_boundaries");
+  for (unsigned int j = 1; j < _energy_group_boundaries.size(); ++j)
+    if (_energy_group_boundaries[j] >= _energy_group_boundaries[j - 1])
+      mooseError("energy_group_boundaries must be ordered from high to low");
 }
 
 void

--- a/src/utils/DiscreteFissionPKAPDF.C
+++ b/src/utils/DiscreteFissionPKAPDF.C
@@ -103,7 +103,7 @@ DiscreteFissionPKAPDF::drawSample(std::vector<MyTRIM_NS::IonBase> & initial_stat
 
   // the real random variables also need to be resampled uniformly
   // within bin index[j]
-  auto neutron_energy = (_energies[sampled_indices[1] + 1] - _energies[sampled_indices[1]]) * MooseRandom::rand() + _energies[sampled_indices[1]];
+  auto neutron_energy = (_energies[sampled_indices[1]] - _energies[sampled_indices[1] + 1]) * MooseRandom::rand() + _energies[sampled_indices[1] + 1];
 
   // pull the right fission yield table and sample Z, A, and energy
   auto energy = MagpieUtils::determineNeutronType(neutron_energy);
@@ -269,7 +269,7 @@ DiscreteFissionPKAPDF::computeMagnitude(MultiIndex<Real> probabilities)
   for (auto it : probabilities)
   {
     MultiIndex<Real>::size_type index = it.first;
-    Real delE = _energies[index[1] + 1] - _energies[index[1]];
+    Real delE = _energies[index[1]] - _energies[index[1] + 1];
     _magnitude += delE * it.second;
   }
 }

--- a/src/utils/DiscretePKAPDF.C
+++ b/src/utils/DiscretePKAPDF.C
@@ -38,7 +38,7 @@ DiscretePKAPDF::precomputeCDF(MultiIndex<Real> probabilities)
   for (auto it: probabilities)
   {
     index = it.first;
-    Real wt = _dmu * _dphi * (_energies[index[1] + 1] - _energies[index[1]]);
+    Real wt = _dmu * _dphi * (_energies[index[1]] - _energies[index[1] + 1]);
     it.second *= wt;
   }
 
@@ -196,7 +196,7 @@ DiscretePKAPDF::drawSample(std::vector<MyTRIM_NS::IonBase> & initial_state) cons
 
   // the real random variables also need to be resampled uniformly
   // within bin index[j]
-  initial_state[0]._E = (_energies[sampled_indices[1] + 1] - _energies[sampled_indices[1]]) * MooseRandom::rand() + _energies[sampled_indices[1]];
+  initial_state[0]._E = (_energies[sampled_indices[1]] - _energies[sampled_indices[1] + 1]) * MooseRandom::rand() + _energies[sampled_indices[1] + 1];
 
   // NOTE: we need to sample the direction in this class because the direction is anisotropic
   Real sampled_phi = _dphi * MooseRandom::rand() + _dphi * sampled_indices[2];
@@ -213,7 +213,7 @@ DiscretePKAPDF::computeMagnitude(MultiIndex<Real> probabilities)
   for (auto it : probabilities)
   {
     MultiIndex<Real>::size_type index = it.first;
-    Real delE = _energies[index[1] + 1] - _energies[index[1]];
+    Real delE = _energies[index[1]] - _energies[index[1] + 1];
     _magnitude += delE * _dphi * _dmu * it.second;
   }
 }
@@ -240,7 +240,7 @@ std::ostream & operator<< (std::ostream & out, const DiscretePKAPDF & pdf)
           RealVectorValue omega(std::cos(phi) * std::sqrt(1 - mu * mu),
                                   std::sin(phi) * std::sqrt(1 - mu * mu), mu);
           out << "Zaid: " << pdf._zaids[jZA]
-              << " Energies: [" << pdf._energies[jE] << ", " << pdf._energies[jE + 1] << "] "
+              << " Energies: [" << pdf._energies[jE + 1] << ", " << pdf._energies[jE] << "] "
               << " mu: [" << jP * pdf._dmu - 1.0 << ", " << (jP + 1) * pdf._dmu - 1.0 << "] "
               << " phi [" << jM * pdf._dphi << ", " << (jM + 1) * pdf._dphi << "] "
               << " omega " << omega

--- a/src/utils/MagpieUtils.C
+++ b/src/utils/MagpieUtils.C
@@ -125,11 +125,11 @@ neutronEnergyName(unsigned int i)
 NeutronEnergyType
 determineNeutronType(Real energy)
 {
-  if (energy < 0.5e-6)
+  if (energy < 0.5)
     return Thermal;
-  else if (energy >= 0.5e-6 && energy < 0.75)
+  else if (energy >= 0.5 && energy < 0.75e6)
     return Epithermal;
-  else if (energy >= 0.75 && energy < 7.0)
+  else if (energy >= 0.75e6 && energy < 7.0e6)
     return Fast;
   return High;
 }

--- a/tests/radiation_damage/coupled_fission_mockup/coupled_fission_mockup.i
+++ b/tests/radiation_damage/coupled_fission_mockup/coupled_fission_mockup.i
@@ -91,13 +91,13 @@
   [./fission_damage_sampler]
     type = NeutronicsSpectrumSamplerFission
     points = '0.5 0.5 0.0'
-    energy_group_boundaries = '0.0 0.5e-6 0.75'
+    energy_group_boundaries = '0.75e6 0.5 0'
     target_isotope_names = 'U235 U238'
     number_densities = 'N92235 N92238'
-    scalar_fluxes = 'scalar_flux_g1 scalar_flux_g0'
+    scalar_fluxes = 'scalar_flux_g0 scalar_flux_g1'
     # each row are the recoil cross sections for a single isotope && all group (g=0,1)
-    fission_cross_sections = '1 0
-                              0 0.01'
+    fission_cross_sections = '0 1
+                              0.01 0'
     execute_on = initial
   [../]
 []

--- a/tests/radiation_damage/pka_distribution/radiation_damage_fission.i
+++ b/tests/radiation_damage/pka_distribution/radiation_damage_fission.i
@@ -73,7 +73,7 @@
   [./pka]
     type = RadiationDamageFission
     points = '0.625 0.625 0.0'
-    energy_group_boundaries = '0 1e-6 20.0'
+    energy_group_boundaries = '20e6 1 0'
     target_isotope_names = 'U235 U238'
     number_densities = 'N92235 N92238'
     scalar_fluxes = 'flux_moment_g0_L0_M0 flux_moment_g1_L0_M0'

--- a/tests/radiation_damage/pka_distribution/radiation_damage_sn.i
+++ b/tests/radiation_damage/pka_distribution/radiation_damage_sn.i
@@ -80,7 +80,7 @@
     type = RadiationDamageSN
     L = 1
     points = '0.625 0.625 0.0'
-    energy_group_boundaries = '0 1e-6 20.0'
+    energy_group_boundaries = '20e6 1 0'
     target_isotope_names = 'U235 U238 O16'
     recoil_isotope_names = 'U235 U238 O16'
     number_densities = 'N92235 N92238 N08016'


### PR DESCRIPTION
energy group boundaries are requested in eV now and ordered from hig to low (#239)