### PR TITLE
Make sure PKAs are treated right for interstitial count

### DIFF
--- a/include/userobjects/MyTRIMRasterizer.h
+++ b/include/userobjects/MyTRIMRasterizer.h
@@ -70,9 +70,11 @@ public:
 
   /// element averaged data
   struct AveragedData {
-    AveragedData(unsigned int nvars = 0) : _elements(nvars, 0.0), _site_volume(0.0) {}
+    AveragedData(unsigned int nvars = 0) : _elements(nvars, 0.0), _Z(nvars, 0.0), _M(nvars, 0.0), _site_volume(0.0) {}
 
     std::vector<Real> _elements;
+    std::vector<Real> _Z;
+    std::vector<Real> _M;
     Real _site_volume;
   };
 

--- a/include/userobjects/PKAConstant.h
+++ b/include/userobjects/PKAConstant.h
@@ -24,7 +24,7 @@ class PKAConstant : public PKAGeneratorBase
 public:
   PKAConstant(const InputParameters & parameters);
 
-  virtual void appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list, Real dt, Real vol, const MyTRIMRasterizer::AveragedData &) const;
+  virtual void appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list, Real dt, Real vol, const MyTRIMRasterizer::AveragedData & averaged_data) const;
 
 protected:
   /// Fission rate (per unit volume)

--- a/include/userobjects/PKAFissionFragmentEmpirical.h
+++ b/include/userobjects/PKAFissionFragmentEmpirical.h
@@ -25,7 +25,7 @@ class PKAFissionFragmentEmpirical : public PKAGeneratorBase
 public:
   PKAFissionFragmentEmpirical(const InputParameters & parameters);
 
-  virtual void appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list, Real dt, Real vol, const MyTRIMRasterizer::AveragedData &) const;
+  virtual void appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list, Real dt, Real vol, const MyTRIMRasterizer::AveragedData & averaged_data) const;
 
 protected:
   /// Fission rate (per unit volume) assuming pure fully dense UO2

--- a/include/userobjects/PKAFixedPointGenerator.h
+++ b/include/userobjects/PKAFixedPointGenerator.h
@@ -25,7 +25,7 @@ class PKAFixedPointGenerator : public PKAGeneratorBase
 public:
   PKAFixedPointGenerator(const InputParameters & parameters);
 
-  virtual void appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list, Real dt, Real vol, const MyTRIMRasterizer::AveragedData &) const;
+  virtual void appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list, Real dt, Real vol, const MyTRIMRasterizer::AveragedData & averaged_data) const;
   virtual void meshChanged() { updateCachedElementID(); }
 
 protected:

--- a/include/userobjects/PKAGeneratorBase.h
+++ b/include/userobjects/PKAGeneratorBase.h
@@ -44,6 +44,9 @@ protected:
 
   /// Return a point with random uniformly distributed coordinates in the unit cube (temp variables are required to ensure execution order!)
   Point getRandomPoint() const { const Real X = getRandomReal(), Y = getRandomReal(), Z = getRandomReal(); return Point(X,Y,Z); }
+
+  /// finds the right ion tag; -1 means that the nuclide is not tracked, otherwise the index in the rasterizer nuclide vector must be retrieved
+  int ionTag(const std::vector<Real> & rasterizer_Z, const std::vector<Real> & rasterizer_m, Real Z, Real m) const;
 };
 
 #endif // PKAGENERATORBASE_H

--- a/src/userobjects/MyTRIMRasterizer.C
+++ b/src/userobjects/MyTRIMRasterizer.C
@@ -233,7 +233,11 @@ MyTRIMRasterizer::execute()
 
     // average compositions on the element
     for (unsigned int i = 0; i < _nvars; ++i)
+    {
       average._elements[i] += qpvol * (*_var[i])[qp];
+      average._Z[i] = _trim_charge[i];
+      average._M[i] = _trim_mass[i];
+    }
 
     // average site volume property
     average._site_volume += qpvol * _site_volume_prop[qp];

--- a/src/userobjects/PKAConstant.C
+++ b/src/userobjects/PKAConstant.C
@@ -29,10 +29,12 @@ PKAConstant::PKAConstant(const InputParameters & parameters) :
 }
 
 void
-PKAConstant::appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list, Real dt, Real vol, const MyTRIMRasterizer::AveragedData &) const
+PKAConstant::appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list, Real dt, Real vol, const MyTRIMRasterizer::AveragedData & averaged_data) const
 {
   mooseAssert(dt >= 0, "Passed a negative time window into PKAConstant::appendPKAs");
   mooseAssert(vol >= 0, "Passed a negative volume into PKAConstant::appendPKAs");
+
+  int tag = ionTag(averaged_data._Z, averaged_data._M, _Z, _m);
 
   unsigned int num_pka = std::floor(dt * vol * _pka_rate + getRandomReal());
 
@@ -48,7 +50,7 @@ PKAConstant::appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list, Real dt, Rea
 
     // the tag is the element this PKA get registered as upon stopping
     // -1 means the PKA will be ignored
-    pka._tag = -1;
+    pka._tag = tag;
 
     // set stopping criteria
     pka.setEf();

--- a/src/userobjects/PKAFissionFragmentEmpirical.C
+++ b/src/userobjects/PKAFissionFragmentEmpirical.C
@@ -25,7 +25,7 @@ PKAFissionFragmentEmpirical::PKAFissionFragmentEmpirical(const InputParameters &
 }
 
 void
-PKAFissionFragmentEmpirical::appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list, Real dt, Real vol, const MyTRIMRasterizer::AveragedData &) const
+PKAFissionFragmentEmpirical::appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list, Real dt, Real vol, const MyTRIMRasterizer::AveragedData & averaged_data) const
 {
   mooseAssert(dt >= 0, "Passed a negative time window into PKAFissionFragmentEmpirical::appendPKAs");
   mooseAssert(vol >= 0, "Passed a negative volume into PKAFissionFragmentEmpirical::appendPKAs");
@@ -62,8 +62,8 @@ PKAFissionFragmentEmpirical::appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_li
 
     // the tag is the element this PKA get registered as upon stopping
     // -1 means the PKA will be ignored
-    ion1._tag = -1;
-    ion2._tag = -1;
+    ion1._tag = ionTag(averaged_data._Z, averaged_data._M, ion1._Z, ion1._m);
+    ion2._tag = ionTag(averaged_data._Z, averaged_data._M, ion2._Z, ion2._m);
 
     // set location of the fission event
     setPosition(ion1);

--- a/src/userobjects/PKAFissionFragmentNeutronics.C
+++ b/src/userobjects/PKAFissionFragmentNeutronics.C
@@ -87,8 +87,8 @@ PKAFissionFragmentNeutronics::appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_l
 
       // the tag is the element this PKA get registered as upon stopping
       // -1 means the PKA will be ignored
-      ion[0]._tag = -1;
-      ion[1]._tag = -1;
+      ion[0]._tag = ionTag(averaged_data._Z, averaged_data._M, ion[0]._Z, ion[0]._m);
+      ion[1]._tag = ionTag(averaged_data._Z, averaged_data._M, ion[1]._Z, ion[1]._m);
 
       // set location of the fission event
       setPosition(ion[0]);

--- a/src/userobjects/PKAFixedPointGenerator.C
+++ b/src/userobjects/PKAFixedPointGenerator.C
@@ -36,7 +36,7 @@ PKAFixedPointGenerator::PKAFixedPointGenerator(const InputParameters & parameter
 }
 
 void
-PKAFixedPointGenerator::appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list, Real /*dt*/, Real /*vol*/, const MyTRIMRasterizer::AveragedData &) const
+PKAFixedPointGenerator::appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list, Real /*dt*/, Real /*vol*/, const MyTRIMRasterizer::AveragedData & averaged_data) const
 {
   if (_current_elem->id() != _elem_id)
     return;
@@ -53,7 +53,7 @@ PKAFixedPointGenerator::appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list, R
 
     // the tag is the element this PKA get registered as upon stopping
     // -1 means the PKA will be ignored
-    pka._tag = -1;
+    pka._tag = ionTag(averaged_data._Z, averaged_data._M, pka._Z, pka._m);;
 
     // set stopping criteria
     pka.setEf();

--- a/src/userobjects/PKAGeneratorBase.C
+++ b/src/userobjects/PKAGeneratorBase.C
@@ -8,6 +8,7 @@
 
 #include "PKAGeneratorBase.h"
 #include "MagpieUtils.h"
+#include <algorithm>
 
 template<>
 InputParameters validParams<PKAGeneratorBase>()
@@ -27,6 +28,21 @@ void
 PKAGeneratorBase::setPosition(MyTRIM_NS::IonBase & ion) const
 {
   ion._pos = MagpieUtils::randomElementPoint(*_current_elem, getRandomPoint());
+}
+
+int
+PKAGeneratorBase::ionTag(const std::vector<Real> & rasterizer_Z, const std::vector<Real> & rasterizer_m, Real Z, Real m) const
+{
+  // this function relies on the exact representation of whole numbers in IEEE floating point numbers
+  // up to a reasonable upper limit [Z < m < 300]
+  const auto & it = std::find(rasterizer_Z.begin(), rasterizer_Z.end(), Z);
+  if (it != rasterizer_Z.end())
+  {
+    unsigned int index = std::distance(rasterizer_Z.begin(), it);
+    if (rasterizer_m[index] == m)
+      return index;
+  }
+  return -1;
 }
 
 void


### PR DESCRIPTION
If a PKA is one of the tracked nuclides, we need to tag it right so it is accounted for in the interstitial count.  