### PR TITLE
bug in recoil rate sampler

### DIFF
--- a/include/vectorpostprocessors/IsotopeRecoilRateSampler.h
+++ b/include/vectorpostprocessors/IsotopeRecoilRateSampler.h
@@ -40,7 +40,7 @@ protected:
   std::vector<unsigned int> _point_ids;
   const NeutronicsSpectrumSamplerBase & _neutronics_sampler;
 
-  std::vector<Real> _recoil_rates;
+  std::vector<Real> & _recoil_rates;
 };
 
 #endif


### PR DESCRIPTION
_recoil_rates must be a reference so it is picked up when being resized (#262)
closes #262 