### PR TITLE
Fix recombination radius

### DIFF
--- a/src/other/MooseMyTRIMEnergyDeposition.C
+++ b/src/other/MooseMyTRIMEnergyDeposition.C
@@ -24,6 +24,7 @@ MooseMyTRIMEnergyDeposition::checkPKAState()
   {
     // PKA is gone, and with it all energy
     case MyTRIM_NS::IonBase::LOST:
+    case MyTRIM_NS::IonBase::DELETE:
       return;
 
     // only deposit electronic stopping (PKA is moving on)

--- a/src/other/ThreadedRecoilLoopBase.C
+++ b/src/other/ThreadedRecoilLoopBase.C
@@ -170,7 +170,7 @@ ThreadedRecoilLoopBase::operator() (const PKARange & pka_list)
       mooseAssert(kd_tree != nullptr, "KDTree was not properly initialized.");
       kd_tree->buildIndex();
 
-      const Real r_rec = _trim_parameters.r_rec;
+      const Real r_rec2 = _trim_parameters.r_rec * _trim_parameters.r_rec;
       nanoflann::SearchParams params;
 
       // 2. iterate over interstitials and recombine them if they are with r_rec of a vacancy
@@ -178,7 +178,7 @@ ThreadedRecoilLoopBase::operator() (const PKARange & pka_list)
       for (auto & i: _interstitial_buffer)
       {
         ret_matches.clear();
-        std::size_t n_result = kd_tree->radiusSearch(&(i.first(0)), r_rec, ret_matches, params);
+        std::size_t n_result = kd_tree->radiusSearch(&(i.first(0)), r_rec2, ret_matches, params);
 
         for (std::size_t j = 0; j < n_result; ++j)
         {

--- a/tests/userobjects/mytrim/cascade_recombine.i
+++ b/tests/userobjects/mytrim/cascade_recombine.i
@@ -72,7 +72,7 @@
     Z = 20
     site_volume = 0.0404 # nm^3 per UO2 unit
     pka_generator = thermal_fission
-    r_rec = 25
+    r_rec = 5
   [../]
   [./runner]
     type = MyTRIMElementRun


### PR DESCRIPTION
recombination radius now _really_ means recombination radius and _not_ square of the recombination radius. As a bonus a compiler warning is fixed as well.

Closes #319