### PR TITLE
Update call to YAKXS::Utility::getAZFromIsotopeName()

### DIFF
--- a/src/userobjects/NeutronicsSpectrumSamplerBase.C
+++ b/src/userobjects/NeutronicsSpectrumSamplerBase.C
@@ -58,7 +58,7 @@ NeutronicsSpectrumSamplerBase::NeutronicsSpectrumSamplerBase(const InputParamete
 #ifdef RATTLESNAKE_ENABLED
     unsigned int Z, A;
     // check if isotope names are valid, NOTE: error handling is delegated to Yakxs::Utilities
-    YAKXS::Utility::getAZFromIsotopeName(_target_isotope_names[i], A, Z);
+    YAKXS::Utility::getAZ(_target_isotope_names[i], A, Z);
     // convert from name to ZAID
     _zaids[i] = YAKXS::Utility::stringToZaid(_target_isotope_names[i]);
 #else

--- a/src/userobjects/NeutronicsSpectrumSamplerSN.C
+++ b/src/userobjects/NeutronicsSpectrumSamplerSN.C
@@ -53,7 +53,7 @@ NeutronicsSpectrumSamplerSN::NeutronicsSpectrumSamplerSN(const InputParameters &
     mooseError("recoil_isotope_names have wrong length.");
   unsigned int Z, A;
   for (unsigned int i = 0; i < _I; ++i)
-    YAKXS::Utility::getAZFromIsotopeName(_recoil_isotope_names[i], A, Z);
+    YAKXS::Utility::getAZ(_recoil_isotope_names[i], A, Z);
 
   // get angular fluxes
   _angular_flux.resize(_G);


### PR DESCRIPTION
These were changed in https://hpcgitlab.hpc.inl.gov/idaholab/rattlesnake/merge_requests/455

This is a test of the new civet recipe that compiles mammoth with magpie.
This just gets things to compile. Mammoth tests will still fail.
