### PR TITLE
Remove mass and Z from average data, refactor ionTag() 

### DIFF
--- a/include/userobjects/MyTRIMRasterizer.h
+++ b/include/userobjects/MyTRIMRasterizer.h
@@ -12,6 +12,7 @@
 #include "ElementUserObject.h"
 
 #include <map>
+#include <array>
 #include <vector>
 
 #include "mytrim/ion.h"
@@ -57,15 +58,31 @@ public:
   /// element averaged data
   struct AveragedData
   {
-    AveragedData(unsigned int nvars = 0)
-      : _elements(nvars, 0.0), _Z(nvars, 0.0), _M(nvars, 0.0), _site_volume(0.0)
-    {
-    }
+    AveragedData(unsigned int nvars = 0) : _elements(nvars, 0.0), _site_volume(0.0) {}
 
     std::vector<Real> _elements;
-    std::vector<Real> _Z;
-    std::vector<Real> _M;
     Real _site_volume;
+  };
+
+  struct PKAParameters
+  {
+    /// masses charges (m_i, Z_i) of the matrix elements
+    std::vector<std::pair<Real, Real>> _mass_charge_pair;
+
+    /// how many isotopes to we have for each element? (only support up to Z=119!)
+    std::array<unsigned int, 120> _num_Z;
+
+    /// if only one element with a specific Z is present point to its rasterizer index here for fast lookup
+    std::array<std::size_t, 120> _single_Z_index;
+
+    /// time interval over which the PKAs are added
+    Real _dt;
+
+    /// recoil rate scaling
+    Real _recoil_rate_scaling;
+
+    /// current element volume
+    Real _volume;
   };
 
   enum TRIMModuleEnum
@@ -141,6 +158,9 @@ protected:
   /// Simulation parameters
   TrimParameters _trim_parameters;
 
+  /// Global (non-spatial dependent) parameters required for PKA generation
+  PKAParameters _pka_parameters;
+
   /// coupled variable values
   std::vector<const VariableValue *> _var;
 
@@ -152,7 +172,7 @@ protected:
   std::vector<const PKAGeneratorBase *> _pka_generators;
   /// @}
 
-  /// @{ material map for the TRIM simulation
+  /// @{ material map for the TRIM simulation (spatial dependent)
   typedef std::map<dof_id_type, AveragedData> MaterialMap;
   MaterialMap _material_map;
   /// @}

--- a/include/userobjects/MyTRIMRasterizer.h
+++ b/include/userobjects/MyTRIMRasterizer.h
@@ -69,11 +69,9 @@ public:
     /// masses charges (m_i, Z_i) of the matrix elements
     std::vector<std::pair<Real, Real>> _mass_charge_pair;
 
-    /// how many isotopes to we have for each element? (only support up to Z=119!)
-    std::array<unsigned int, 120> _num_Z;
-
-    /// if only one element with a specific Z is present point to its rasterizer index here for fast lookup
-    std::array<std::size_t, 120> _single_Z_index;
+    /// how many isotopes to we have for each element and which index contains the
+    /// first Z match? (only support up to Z=119!)
+    std::array<std::pair<unsigned int, std::size_t>, 120> _index_Z;
 
     /// time interval over which the PKAs are added
     Real _dt;

--- a/include/userobjects/PKAEmpiricalBase.h
+++ b/include/userobjects/PKAEmpiricalBase.h
@@ -24,11 +24,9 @@ class PKAEmpiricalBase : public PKAGeneratorBase
 public:
   PKAEmpiricalBase(const InputParameters & parameters);
 
-  virtual void appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list,
-                          Real dt,
-                          Real vol,
-                          Real recoil_rate_scaling,
-                          const MyTRIMRasterizer::AveragedData & averaged_data) const;
+  virtual void appendPKAs(std::vector<MyTRIM_NS::IonBase> &,
+                          const MyTRIMRasterizer::PKAParameters &,
+                          const MyTRIMRasterizer::AveragedData &) const;
 
 protected:
   /// Fission rate (per unit volume)

--- a/include/userobjects/PKAFissionFragmentEmpirical.h
+++ b/include/userobjects/PKAFissionFragmentEmpirical.h
@@ -25,11 +25,9 @@ class PKAFissionFragmentEmpirical : public PKAGeneratorBase
 public:
   PKAFissionFragmentEmpirical(const InputParameters & parameters);
 
-  virtual void appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list,
-                          Real dt,
-                          Real vol,
-                          Real recoil_rate_scaling,
-                          const MyTRIMRasterizer::AveragedData & averaged_data) const;
+  virtual void appendPKAs(std::vector<MyTRIM_NS::IonBase> &,
+                          const MyTRIMRasterizer::PKAParameters &,
+                          const MyTRIMRasterizer::AveragedData &) const;
 
 protected:
   /// Fission rate (per unit volume) assuming pure fully dense UO2

--- a/include/userobjects/PKAFissionFragmentNeutronics.h
+++ b/include/userobjects/PKAFissionFragmentNeutronics.h
@@ -23,10 +23,8 @@ class PKAFissionFragmentNeutronics : public PKAGeneratorNeutronicsBase
 public:
   PKAFissionFragmentNeutronics(const InputParameters & parameters);
 
-  virtual void appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list,
-                          Real dt,
-                          Real vol,
-                          Real recoil_rate_scaling,
+  virtual void appendPKAs(std::vector<MyTRIM_NS::IonBase> &,
+                          const MyTRIMRasterizer::PKAParameters &,
                           const MyTRIMRasterizer::AveragedData &) const;
 
   virtual void setPDF(const std::vector<unsigned int> & ZAID,

--- a/include/userobjects/PKAFixedPointGenerator.h
+++ b/include/userobjects/PKAFixedPointGenerator.h
@@ -25,11 +25,9 @@ class PKAFixedPointGenerator : public PKAGeneratorBase
 public:
   PKAFixedPointGenerator(const InputParameters & parameters);
 
-  virtual void appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list,
-                          Real dt,
-                          Real vol,
-                          Real recoil_rate_scaling,
-                          const MyTRIMRasterizer::AveragedData & averaged_data) const;
+  virtual void appendPKAs(std::vector<MyTRIM_NS::IonBase> &,
+                          const MyTRIMRasterizer::PKAParameters &,
+                          const MyTRIMRasterizer::AveragedData &) const;
   virtual void meshChanged() { updateCachedElementID(); }
 
 protected:

--- a/include/userobjects/PKAGeneratorAlphaDecay.h
+++ b/include/userobjects/PKAGeneratorAlphaDecay.h
@@ -24,10 +24,8 @@ class PKAGeneratorAlphaDecay : public PKAGeneratorBase
 public:
   PKAGeneratorAlphaDecay(const InputParameters & parameters);
 
-  virtual void appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list,
-                          Real dt,
-                          Real vol,
-                          Real recoil_rate_scaling,
+  virtual void appendPKAs(std::vector<MyTRIM_NS::IonBase> &,
+                          const MyTRIMRasterizer::PKAParameters &,
                           const MyTRIMRasterizer::AveragedData &) const override;
 
   /// this stores the decay information for a single alpha decaying nuclide

--- a/include/userobjects/PKAGeneratorBase.h
+++ b/include/userobjects/PKAGeneratorBase.h
@@ -31,10 +31,8 @@ public:
    * Append the ions for the current element and time window dt.
    * The element volume is passed in as it is computed in the MyTRIMRasterizer anyways.
    */
-  virtual void appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list,
-                          Real dt,
-                          Real vol,
-                          Real recoil_rate_scaling,
+  virtual void appendPKAs(std::vector<MyTRIM_NS::IonBase> &,
+                          const MyTRIMRasterizer::PKAParameters &,
                           const MyTRIMRasterizer::AveragedData &) const = 0;
 
   virtual void initialize() {}
@@ -54,10 +52,7 @@ protected:
   }
 
   /// finds the right ion tag; -1 means that the nuclide is not tracked, otherwise the index in the rasterizer nuclide vector must be retrieved
-  int ionTag(const std::vector<Real> & rasterizer_Z,
-             const std::vector<Real> & rasterizer_m,
-             Real Z,
-             Real m) const;
+  int ionTag(const MyTRIMRasterizer::PKAParameters &, Real Z, Real m) const;
 };
 
 #endif // PKAGENERATORBASE_H

--- a/include/userobjects/PKAGeneratorRecoil.h
+++ b/include/userobjects/PKAGeneratorRecoil.h
@@ -23,10 +23,8 @@ class PKAGeneratorRecoil : public PKAGeneratorNeutronicsBase
 public:
   PKAGeneratorRecoil(const InputParameters & parameters);
 
-  virtual void appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list,
-                          Real dt,
-                          Real vol,
-                          Real recoil_rate_scaling,
+  virtual void appendPKAs(std::vector<MyTRIM_NS::IonBase> &,
+                          const MyTRIMRasterizer::PKAParameters &,
                           const MyTRIMRasterizer::AveragedData &) const;
 
   virtual void setPDF(const std::vector<unsigned int> & ZAID,

--- a/src/userobjects/MyTRIMRasterizer.C
+++ b/src/userobjects/MyTRIMRasterizer.C
@@ -16,14 +16,14 @@
 #include "libmesh/parallel_algebra.h"
 
 // custom data load and data store methods for a struct with an std::vector member
-template<>
+template <>
 inline void
 dataStore(std::ostream & stream, MyTRIMRasterizer::AveragedData & ad, void * context)
 {
   dataStore(stream, ad._elements, context);
   dataStore(stream, ad._site_volume, context);
 }
-template<>
+template <>
 inline void
 dataLoad(std::istream & stream, MyTRIMRasterizer::AveragedData & ad, void * context)
 {
@@ -31,8 +31,9 @@ dataLoad(std::istream & stream, MyTRIMRasterizer::AveragedData & ad, void * cont
   dataLoad(stream, ad._site_volume, context);
 }
 
-// custom data load and data store methods for a class with virtual members (vtable pointer must not be (un)serialized)
-template<>
+// custom data load and data store methods for a class with virtual members (vtable pointer must not
+// be (un)serialized)
+template <>
 inline void
 dataStore(std::ostream & stream, MyTRIM_NS::IonBase & pl, void * context)
 {
@@ -48,7 +49,7 @@ dataStore(std::ostream & stream, MyTRIM_NS::IonBase & pl, void * context)
   dataStore(stream, pl._Ef, context);
   dataStore(stream, pl._state, context);
 }
-template<>
+template <>
 inline void
 dataLoad(std::istream & stream, MyTRIM_NS::IonBase & pl, void * context)
 {
@@ -67,19 +68,25 @@ dataLoad(std::istream & stream, MyTRIM_NS::IonBase & pl, void * context)
 
 registerMooseObject("MagpieApp", MyTRIMRasterizer);
 
-template<>
-InputParameters validParams<MyTRIMRasterizer>()
+template <>
+InputParameters
+validParams<MyTRIMRasterizer>()
 {
   InputParameters params = validParams<ElementUserObject>();
-  params.addClassDescription("Gather the element distribution of the simulation domain for a TRIM binary collision Monte Carlo simulation");
+  params.addClassDescription("Gather the element distribution of the simulation domain for a TRIM "
+                             "binary collision Monte Carlo simulation");
   params.addRequiredCoupledVar("var", "Variables to rasterize");
-  params.addCoupledVar("periodic_var", "Optional variables that determines the periodicity. If not supplied the first argument of 'var' will be used.");
+  params.addCoupledVar("periodic_var",
+                       "Optional variables that determines the periodicity. If not supplied the "
+                       "first argument of 'var' will be used.");
   params.addRequiredParam<std::vector<Real>>("M", "Element mass in amu");
   params.addRequiredParam<std::vector<Real>>("Z", "Nuclear charge in e");
   params.addParam<std::vector<Real>>("Ebind", "Binding energy in eV");
   params.addParam<std::vector<Real>>("Edisp", "Displacement threshold in eV");
-  params.addRequiredParam<MaterialPropertyName>("site_volume", "Lattice site volume in nm^3 (regardless of the chosen mesh units)");
-  params.addRequiredParam<std::vector<UserObjectName>>("pka_generator", "List of PKA generating user objects");
+  params.addRequiredParam<MaterialPropertyName>(
+      "site_volume", "Lattice site volume in nm^3 (regardless of the chosen mesh units)");
+  params.addRequiredParam<std::vector<UserObjectName>>("pka_generator",
+                                                       "List of PKA generating user objects");
   ExecFlagEnum setup_options(MooseUtils::getDefaultExecFlagEnum());
 
   // we run this object once a timestep
@@ -88,27 +95,42 @@ InputParameters validParams<MyTRIMRasterizer>()
 
   // which TRIM Module to run for optional capabilities like energy deposition
   MooseEnum trim_module_options("CORE=0 ENERGY_DEPOSITION=1", "CORE");
-  params.addParam<MooseEnum>("trim_module", trim_module_options, "TRIM Module to run for optional capabilities like energy deposition");
+  params.addParam<MooseEnum>("trim_module",
+                             trim_module_options,
+                             "TRIM Module to run for optional capabilities like energy deposition");
 
   // which units of length to use
   MooseEnum length_unit_options("ANGSTROM=0 NANOMETER MICROMETER", "ANGSTROM");
-  params.addParam<MooseEnum>("length_unit", length_unit_options, "Length units of the MOOSE mesh. MyTRIM contains pretabulated crossection data with units so this option must be set correctly to obtain physical results.");
+  params.addParam<MooseEnum>("length_unit",
+                             length_unit_options,
+                             "Length units of the MOOSE mesh. MyTRIM contains pretabulated "
+                             "crossection data with units so this option must be set correctly to "
+                             "obtain physical results.");
 
   // Advanced options
   params.addParam<unsigned int>("interval", 1, "The time step interval at which TRIM BCMC is run");
-  params.addParam<Real>("analytical_energy_cutoff", 0.0, "Energy cutoff in eV below which recoils are not followed explicitly but effects are calculated analytically.");
-  params.addParam<Real>("recoil_rate_scaling", 1.0, "A factor to scale computed reaction rates in the the PKAGenerator objects. This is useful to avoid extremely large PKA lists.");
-  params.addParam<unsigned int>("max_pka_count", "Desired number of PKAs to be run during each invocation of mytrim");
+  params.addParam<Real>("analytical_energy_cutoff",
+                        0.0,
+                        "Energy cutoff in eV below which recoils are not followed explicitly but "
+                        "effects are calculated analytically.");
+  params.addParam<Real>("recoil_rate_scaling",
+                        1.0,
+                        "A factor to scale computed reaction rates in the the PKAGenerator "
+                        "objects. This is useful to avoid extremely large PKA lists.");
+  params.addParam<unsigned int>(
+      "max_pka_count", "Desired number of PKAs to be run during each invocation of mytrim");
   params.addParamNamesToGroup("interval analytical_energy_cutoff max_pka_count", "Advanced");
 
-  params.addParam<Real>("r_rec", "Recombination radius in Angstrom. Frenkel pairs with a separation distance lower than this will be removed from the cascade");
+  params.addParam<Real>("r_rec",
+                        "Recombination radius in Angstrom. Frenkel pairs with a separation "
+                        "distance lower than this will be removed from the cascade");
   params.addParamNamesToGroup("r_rec", "Recombination");
 
   return params;
 }
 
-MyTRIMRasterizer::MyTRIMRasterizer(const InputParameters & parameters) :
-    ElementUserObject(parameters),
+MyTRIMRasterizer::MyTRIMRasterizer(const InputParameters & parameters)
+  : ElementUserObject(parameters),
     _nvars(coupledComponents("var")),
     _dim(_mesh.dimension()),
     _var(_nvars),
@@ -142,8 +164,8 @@ MyTRIMRasterizer::MyTRIMRasterizer(const InputParameters & parameters) :
     mooseError("Parameter 'Z' must have as many components as coupled variables.");
 
   for (unsigned int i = 0; i < _nvars; ++i)
-      if (trim_Z[i] > trim_M[i])
-        mooseError("Value of Z is larger than value of M for entry ", i);
+    if (trim_Z[i] > trim_M[i])
+      mooseError("Value of Z is larger than value of M for entry ", i);
 
   for (unsigned int i = 0; i < _nvars; ++i)
   {
@@ -160,7 +182,8 @@ MyTRIMRasterizer::MyTRIMRasterizer(const InputParameters & parameters) :
     for (unsigned int i = 0; i < _nvars; ++i)
       _trim_parameters.element_prototypes[i]._Elbind = 3.0;
   else
-    mooseError("Parameter 'Ebind' must have as many components as coupled variables (or left empty for a default of 3eV).");
+    mooseError("Parameter 'Ebind' must have as many components as coupled variables (or left empty "
+               "for a default of 3eV).");
 
   auto trim_Edisp = getParam<std::vector<Real>>("Edisp");
   if (trim_Edisp.size() == _nvars)
@@ -170,7 +193,8 @@ MyTRIMRasterizer::MyTRIMRasterizer(const InputParameters & parameters) :
     for (unsigned int i = 0; i < _nvars; ++i)
       _trim_parameters.element_prototypes[i]._Edisp = 25.0;
   else
-    mooseError("Parameter 'Edisp' must have as many components as coupled variables (or left empty for a default of 25eV).");
+    mooseError("Parameter 'Edisp' must have as many components as coupled variables (or left empty "
+               "for a default of 25eV).");
 
   if (isParamValid("r_rec"))
   {
@@ -214,6 +238,28 @@ MyTRIMRasterizer::MyTRIMRasterizer(const InputParameters & parameters) :
     default:
       mooseError("Unknown length unit.");
   }
+
+  // setup invariant PKA generation parameters
+  for (auto & nZ : _pka_parameters._num_Z)
+    nZ = 0;
+  _pka_parameters._mass_charge_pair.resize(_nvars);
+  _pka_parameters._recoil_rate_scaling = _trim_parameters.recoil_rate_scaling;
+  for (unsigned int i = 0; i < _nvars; ++i)
+  {
+    const auto Z = _trim_parameters.element_prototypes[i]._Z;
+
+    // insert (mass, charge) pair
+    _pka_parameters._mass_charge_pair[i] =
+        std::make_pair(_trim_parameters.element_prototypes[i]._m, Z);
+
+    // increase the count of elements with the same Z
+    auto & num_Z = _pka_parameters._num_Z[Z];
+    num_Z++;
+
+    // only set this to the first index (important for ionTag())
+    if (num_Z == 1)
+      _pka_parameters._single_Z_index[Z] = i;
+  }
 }
 
 bool
@@ -238,6 +284,9 @@ MyTRIMRasterizer::initialize()
     _material_map.clear();
     _pka_list.clear();
   }
+
+  /// setup global PKA parameters for the current timestep
+  _pka_parameters._dt = _accumulated_time + _fe_problem.dt();
 }
 
 void
@@ -260,12 +309,7 @@ MyTRIMRasterizer::execute()
 
     // average compositions on the element
     for (unsigned int i = 0; i < _nvars; ++i)
-    {
-
       average._elements[i] += qpvol * (*_var[i])[qp];
-      average._M[i] = _trim_parameters.element_prototypes[i]._m;
-      average._Z[i] = _trim_parameters.element_prototypes[i]._Z;
-    }
 
     // average site volume property
     average._site_volume += qpvol * _site_volume_prop[qp];
@@ -283,13 +327,16 @@ MyTRIMRasterizer::execute()
   // store in map
   _material_map[_current_elem->id()] = average;
 
+  // update corrent element volume
+  _pka_parameters._volume = vol;
+
   // add PKAs for current element
   for (auto && gen : _pka_generators)
-    gen->appendPKAs(_pka_list, _accumulated_time + _fe_problem.dt(), vol, _trim_parameters.recoil_rate_scaling, average);
+    gen->appendPKAs(_pka_list, _pka_parameters, average);
 }
 
 void
-MyTRIMRasterizer::threadJoin(const UserObject &y)
+MyTRIMRasterizer::threadJoin(const UserObject & y)
 {
   // if the map needs to be updated we merge the maps from all threads
   if (_execute_this_timestep)
@@ -348,8 +395,7 @@ MyTRIMRasterizer::finalize()
 
     // sort PKA list only on processor 0 & assign random number seeds
     std::sort(_pka_list.begin(), _pka_list.end(), [](MyTRIM_NS::IonBase a, MyTRIM_NS::IonBase b) {
-      return (a._pos < b._pos) ||
-             (a._pos == b._pos && a._m < b._m) ||
+      return (a._pos < b._pos) || (a._pos == b._pos && a._m < b._m) ||
              (a._pos == b._pos && a._m == b._m && a._E < b._E) ||
              (a._pos == b._pos && a._m == b._m && a._E == b._E && a._Z < b._Z);
     });
@@ -361,7 +407,8 @@ MyTRIMRasterizer::finalize()
 
   // rejection is performed in processor 0 only
   _trim_parameters.original_npka = _pka_list.size();
-  if (_trim_parameters.desired_npka == 0 || _trim_parameters.desired_npka > _trim_parameters.original_npka)
+  if (_trim_parameters.desired_npka == 0 ||
+      _trim_parameters.desired_npka > _trim_parameters.original_npka)
   {
     _trim_parameters.scaled_npka = _trim_parameters.original_npka;
     _trim_parameters.result_scaling_factor = 1.0 / _trim_parameters.recoil_rate_scaling;
@@ -370,7 +417,8 @@ MyTRIMRasterizer::finalize()
   {
     if (processor_id() == 0)
     {
-      Real acceptance_probability = Real(_trim_parameters.desired_npka) / Real(_trim_parameters.original_npka);
+      Real acceptance_probability =
+          Real(_trim_parameters.desired_npka) / Real(_trim_parameters.original_npka);
 
       // most straight-forward but probably inefficient implementation of rejection
       std::vector<MyTRIM_NS::IonBase> old_pka_list = _pka_list;
@@ -381,7 +429,9 @@ MyTRIMRasterizer::finalize()
 
       // save the size of the PKA list after rejection & the scaling factor
       _trim_parameters.scaled_npka = _pka_list.size();
-      _trim_parameters.result_scaling_factor = Real(_trim_parameters.original_npka) / Real(_trim_parameters.scaled_npka) / _trim_parameters.recoil_rate_scaling;
+      _trim_parameters.result_scaling_factor = Real(_trim_parameters.original_npka) /
+                                               Real(_trim_parameters.scaled_npka) /
+                                               _trim_parameters.recoil_rate_scaling;
     }
 
     // need to broadcast the size of the PKA list after rejection & result scaling factor
@@ -417,7 +467,7 @@ MyTRIMRasterizer::finalize()
     // split PKAs into per-processor ranges
     std::vector<unsigned int> interval(_app.n_processors() + 1, 0);
     for (unsigned int i = 0; i < _app.n_processors(); ++i)
-      interval[i+1] = (_pka_list.size() - interval[i]) / (_app.n_processors() - i) + interval[i];
+      interval[i + 1] = (_pka_list.size() - interval[i]) / (_app.n_processors() - i) + interval[i];
 
     auto begin = interval[processor_id()];
     auto end = interval[processor_id() + 1];
@@ -486,7 +536,8 @@ MyTRIMRasterizer::serialize(std::string & serialized_buffer)
 void
 MyTRIMRasterizer::deserialize(std::vector<std::string> & serialized_buffers)
 {
-  mooseAssert(serialized_buffers.size() == _app.n_processors(), "Unexpected size of serialized_buffers: " << serialized_buffers.size());
+  mooseAssert(serialized_buffers.size() == _app.n_processors(),
+              "Unexpected size of serialized_buffers: " << serialized_buffers.size());
 
   // The input string stream used for deserialization
   std::istringstream iss;

--- a/src/userobjects/PKAEmpiricalBase.C
+++ b/src/userobjects/PKAEmpiricalBase.C
@@ -8,21 +8,28 @@
 
 #include "PKAEmpiricalBase.h"
 
-template<>
-InputParameters validParams<PKAEmpiricalBase>()
+template <>
+InputParameters
+validParams<PKAEmpiricalBase>()
 {
   InputParameters params = validParams<PKAGeneratorBase>();
   return params;
 }
 
-PKAEmpiricalBase::PKAEmpiricalBase(const InputParameters & parameters) :
-    PKAGeneratorBase(parameters)
+PKAEmpiricalBase::PKAEmpiricalBase(const InputParameters & parameters)
+  : PKAGeneratorBase(parameters)
 {
 }
 
 void
-PKAEmpiricalBase::appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list, Real dt, Real vol, Real recoil_rate_scaling, const MyTRIMRasterizer::AveragedData & averaged_data) const
+PKAEmpiricalBase::appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list,
+                             const MyTRIMRasterizer::PKAParameters & pka_parameters,
+                             const MyTRIMRasterizer::AveragedData &) const
 {
+  const auto dt = pka_parameters._dt;
+  const auto vol = pka_parameters._volume;
+  const auto recoil_rate_scaling = pka_parameters._recoil_rate_scaling;
+
   mooseAssert(dt >= 0, "Passed a negative time window into PKAEmpiricalBase::appendPKAs");
   mooseAssert(vol >= 0, "Passed a negative volume into PKAEmpiricalBase::appendPKAs");
 
@@ -30,9 +37,10 @@ PKAEmpiricalBase::appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list, Real dt
   const Real m = getM();
   const Real E = getE();
 
-  int tag = ionTag(averaged_data._Z, averaged_data._M, Z, m);
+  int tag = ionTag(pka_parameters, Z, m);
 
-  unsigned int num_pka = std::floor(recoil_rate_scaling * dt * vol * getPKARate() + getRandomReal());
+  unsigned int num_pka =
+      std::floor(recoil_rate_scaling * dt * vol * getPKARate() + getRandomReal());
 
   for (unsigned i = 0; i < num_pka; ++i)
   {

--- a/src/userobjects/PKAFixedPointGenerator.C
+++ b/src/userobjects/PKAFixedPointGenerator.C
@@ -11,12 +11,15 @@
 
 registerMooseObject("MagpieApp", PKAFixedPointGenerator);
 
-template<>
-InputParameters validParams<PKAFixedPointGenerator>()
+template <>
+InputParameters
+validParams<PKAFixedPointGenerator>()
 {
   InputParameters params = validParams<PKAGeneratorBase>();
-  params.addClassDescription("This PKAGenerator starts particle from a fixed point in a random direction (isotropically).");
-  params.addParam<unsigned int>("num_pkas", 1000, "The number of PKAs to be started from this position");
+  params.addClassDescription("This PKAGenerator starts particle from a fixed point in a random "
+                             "direction (isotropically).");
+  params.addParam<unsigned int>(
+      "num_pkas", 1000, "The number of PKAs to be started from this position");
   params.addRequiredParam<Point>("point", "The point from which the PKAs are started");
   params.addRequiredParam<Real>("Z", "PKA nuclear charge");
   params.addRequiredParam<Real>("m", "PKA mass in amu");
@@ -24,8 +27,8 @@ InputParameters validParams<PKAFixedPointGenerator>()
   return params;
 }
 
-PKAFixedPointGenerator::PKAFixedPointGenerator(const InputParameters & parameters) :
-    PKAGeneratorBase(parameters),
+PKAFixedPointGenerator::PKAFixedPointGenerator(const InputParameters & parameters)
+  : PKAGeneratorBase(parameters),
     _num_pka(getParam<unsigned int>("num_pkas")),
     _point(getParam<Point>("point")),
     _Z(getParam<Real>("Z")),
@@ -38,14 +41,16 @@ PKAFixedPointGenerator::PKAFixedPointGenerator(const InputParameters & parameter
 }
 
 void
-PKAFixedPointGenerator::appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list, Real /*dt*/, Real /*vol*/, Real recoil_rate_scaling, const MyTRIMRasterizer::AveragedData & averaged_data) const
+PKAFixedPointGenerator::appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list,
+                                   const MyTRIMRasterizer::PKAParameters & pka_parameters,
+                                   const MyTRIMRasterizer::AveragedData &) const
 {
   if (_current_elem->id() != _elem_id)
     return;
 
   unsigned int num_pka = _num_pka;
-  if (recoil_rate_scaling != 1)
-    num_pka = std::floor(recoil_rate_scaling * _num_pka + getRandomReal());
+  if (pka_parameters._recoil_rate_scaling != 1)
+    num_pka = std::floor(pka_parameters._recoil_rate_scaling * _num_pka + getRandomReal());
 
   for (unsigned i = 0; i < _num_pka; ++i)
   {
@@ -59,7 +64,8 @@ PKAFixedPointGenerator::appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list, R
 
     // the tag is the element this PKA get registered as upon stopping
     // -1 means the PKA will be ignored
-    pka._tag = ionTag(averaged_data._Z, averaged_data._M, pka._Z, pka._m);;
+    pka._tag = ionTag(pka_parameters, pka._Z, pka._m);
+    ;
 
     // set stopping criteria
     pka.setEf();

--- a/src/userobjects/PKAGeneratorBase.C
+++ b/src/userobjects/PKAGeneratorBase.C
@@ -41,15 +41,15 @@ PKAGeneratorBase::ionTag(const MyTRIMRasterizer::PKAParameters & pka_parameters,
   // numbers up to a reasonable upper limit [Z < m < 300]
 
   // element not found in rasterizer table
-  if (pka_parameters._num_Z[Z] == 0)
+  if (pka_parameters._index_Z[Z].first == 0)
     return -1;
 
-  if (pka_parameters._num_Z[Z] == 1)
-    return pka_parameters._single_Z_index[Z];
+  if (pka_parameters._index_Z[Z].first == 1)
+    return pka_parameters._index_Z[Z].second;
 
   const auto & mZ = pka_parameters._mass_charge_pair;
   // start the search at the firsat matching Z
-  for (auto i = pka_parameters._single_Z_index[Z]; i < mZ.size(); ++i)
+  for (auto i = pka_parameters._index_Z[Z].second; i < mZ.size(); ++i)
     if (mZ[i].second == Z && mZ[i].first == m)
       return i;
 

--- a/src/userobjects/PKAGeneratorBase.C
+++ b/src/userobjects/PKAGeneratorBase.C
@@ -53,11 +53,8 @@ PKAGeneratorBase::ionTag(const MyTRIMRasterizer::PKAParameters & pka_parameters,
     if (mZ[i].second == Z && mZ[i].first == m)
       return i;
 
-  mooseError("Unexpectedly did not find the element with Z=",
-             Z,
-             " m=",
-             m,
-             ". Inconsistency in _numZ and _single_Z_index.");
+  // no matching mass (isotope) found for the given Z
+  return -1;
 }
 
 void

--- a/src/userobjects/PKAGeneratorRecoil.C
+++ b/src/userobjects/PKAGeneratorRecoil.C
@@ -12,31 +12,42 @@
 
 registerMooseObject("MagpieApp", PKAGeneratorRecoil);
 
-template<>
-InputParameters validParams<PKAGeneratorRecoil>()
+template <>
+InputParameters
+validParams<PKAGeneratorRecoil>()
 {
   InputParameters params = validParams<PKAGeneratorNeutronicsBase>();
-  params.addClassDescription("PKA recoil generator user object.\n Takes pdf and samples PKAs due to recoil reaction.");
+  params.addClassDescription(
+      "PKA recoil generator user object.\n Takes pdf and samples PKAs due to recoil reaction.");
   return params;
 }
 
-PKAGeneratorRecoil::PKAGeneratorRecoil(const InputParameters & parameters):
-    PKAGeneratorNeutronicsBase(parameters)
+PKAGeneratorRecoil::PKAGeneratorRecoil(const InputParameters & parameters)
+  : PKAGeneratorNeutronicsBase(parameters)
 {
 }
 
 void
-PKAGeneratorRecoil::setPDF(const std::vector<unsigned int> & ZAID, const std::vector<Real> & energies, const MultiIndex<Real> & probabilities)
+PKAGeneratorRecoil::setPDF(const std::vector<unsigned int> & ZAID,
+                           const std::vector<Real> & energies,
+                           const MultiIndex<Real> & probabilities)
 {
   _pdf = DiscretePKAPDF(ZAID, energies, probabilities);
-  #if DEBUG
-    _console << "\nPKAGeneratorRecoil object received the following pdf from DiscretePKAPDF object:\n" << _pdf;
-  #endif
+#if DEBUG
+  _console << "\nPKAGeneratorRecoil object received the following pdf from DiscretePKAPDF object:\n"
+           << _pdf;
+#endif
 }
 
 void
-PKAGeneratorRecoil::appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list, Real dt, Real vol, Real recoil_rate_scaling, const MyTRIMRasterizer::AveragedData & averaged_data) const
+PKAGeneratorRecoil::appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list,
+                               const MyTRIMRasterizer::PKAParameters & pka_parameters,
+                               const MyTRIMRasterizer::AveragedData & averaged_data) const
 {
+  const auto dt = pka_parameters._dt;
+  const auto vol = pka_parameters._volume;
+  const auto recoil_rate_scaling = pka_parameters._recoil_rate_scaling;
+
   mooseAssert(dt >= 0, "Passed a negative time window into PKAGeneratorRecoil::appendPKAs");
   mooseAssert(vol >= 0, "Passed a negative volume into PKAGeneratorRecoil::appendPKAs");
 
@@ -45,9 +56,10 @@ PKAGeneratorRecoil::appendPKAs(std::vector<MyTRIM_NS::IonBase> & ion_list, Real 
 
   for (unsigned int nuclide = 0; nuclide < _partial_neutronics_reaction_rates.size(); ++nuclide)
   {
-    unsigned int num_recoils = std::floor(recoil_rate_scaling * dt * vol *
-                               (*_partial_neutronics_reaction_rates[nuclide]) / (*_averaged_number_densities[nuclide])
-                               * averaged_data._elements[nuclide] + getRandomReal());
+    unsigned int num_recoils =
+        std::floor(recoil_rate_scaling * dt * vol * (*_partial_neutronics_reaction_rates[nuclide]) /
+                       (*_averaged_number_densities[nuclide]) * averaged_data._elements[nuclide] +
+                   getRandomReal());
 
     for (unsigned i = 0; i < num_recoils; ++i)
     {

--- a/src/userobjects/PKAGun.C
+++ b/src/userobjects/PKAGun.C
@@ -10,18 +10,19 @@
 
 registerMooseObject("MagpieApp", PKAGun);
 
-template<>
-InputParameters validParams<PKAGun>()
+template <>
+InputParameters
+validParams<PKAGun>()
 {
   InputParameters params = validParams<PKAFixedPointGenerator>();
-  params.addClassDescription("This PKAGenerator starts particle from a fixed point in a fixed direction.");
+  params.addClassDescription(
+      "This PKAGenerator starts particle from a fixed point in a fixed direction.");
   params.addRequiredParam<Point>("direction", "The fixed direction the PKAs move along");
   return params;
 }
 
-PKAGun::PKAGun(const InputParameters & parameters) :
-    PKAFixedPointGenerator(parameters),
-    _direction(getParam<Point>("direction"))
+PKAGun::PKAGun(const InputParameters & parameters)
+  : PKAFixedPointGenerator(parameters), _direction(getParam<Point>("direction"))
 {
 }
 


### PR DESCRIPTION
Move stuff that is not spatially dependent out of `AverageData`, create new `PKAData` structure to pass data to the generators. Rewrite `ionTag()` using this new data structure, which also holds some pretabulated search data (number of elements with a given Z, first rasterizer index to match a given Z)

Closes #333