### PR TITLE
Protect GSL code, ignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,5 +158,12 @@ peacock_*.e
 *.cpa-*
 *.cpr-*
 
+build
+
 include/base/MagpieRevision.h
 tests/userobjects/spparks/log.spparks
+
+.failed_tests
+.previous_test_results.json
+
+compile_commands.json

--- a/include/userobjects/NeutronicsSpectrumSamplerSN.h
+++ b/include/userobjects/NeutronicsSpectrumSamplerSN.h
@@ -5,8 +5,9 @@
 /*            Copyright 2017 Battelle Energy Alliance, LLC            */
 /*                        ALL RIGHTS RESERVED                         */
 /**********************************************************************/
-
+#ifdef GSL_ENABLED
 #ifdef RATTLESNAKE_ENABLED
+
 #ifndef NEUTRONICSSPECTRUMSAMPLERSN_H
 #define NEUTRONICSSPECTRUMSAMPLERSN_H
 
@@ -56,4 +57,6 @@ protected:
 };
 
 #endif // NEUTRONICSSPECTRUMSAMPLERSN_H
+
 #endif // RATTLESNAKE_ENABLED
+#endif // GSL_ENABLED


### PR DESCRIPTION
Fixes up more stuff to build without GSL. As a bonus the `.gitignore` file is updated as well.

Refs #230