### PR TITLE
Explicitly call dot() in classes which need _u_dot().

### DIFF
--- a/include/postprocessors/TemporalCorrelation.h
+++ b/include/postprocessors/TemporalCorrelation.h
@@ -29,6 +29,7 @@ public:
 protected:
   virtual Real computeQpIntegral() override;
   virtual Real getValue() override;
+  const VariableValue & _u_dot;
 };
 
 #endif // TEMPORALCORRELATION_H

--- a/src/postprocessors/TemporalCorrelation.C
+++ b/src/postprocessors/TemporalCorrelation.C
@@ -20,7 +20,7 @@ validParams<TemporalCorrelation>()
 }
 
 TemporalCorrelation::TemporalCorrelation(const InputParameters & parameters)
-  : ElementAverageValue(parameters)
+  : ElementAverageValue(parameters), _u_dot(dot())
 {
 }
 


### PR DESCRIPTION
Refs idaholab/moose#12185.

@dschwen normally I would update the moose submodule of the app but magpie does not seem to have a MOOSE submodule. Do you always build against upstream master? devel?

