### PR TITLE
Fullapp reentering fix

### DIFF
--- a/src/transfers/MultiAppNeutronicsSpectrumTransfer.C
+++ b/src/transfers/MultiAppNeutronicsSpectrumTransfer.C
@@ -58,8 +58,8 @@ MultiAppNeutronicsSpectrumTransfer::execute()
       for (THREAD_ID tid = 0; tid < libMesh::n_threads(); ++tid)
       {
         PKAGeneratorNeutronicsBase & pka_uo = const_cast<PKAGeneratorNeutronicsBase &>(
-            _multi_app->appProblem(i).getUserObject<PKAGeneratorNeutronicsBase>(_pka_generator_name,
-                                                                                tid));
+            _multi_app->appProblemBase(i).getUserObject<PKAGeneratorNeutronicsBase>(
+                _pka_generator_name, tid));
         pka_uo.setPDF(zaids, energies, probabilities);
       }
     }

--- a/tests/radiation_damage/coupled_fission_mockup/damage_sub.i
+++ b/tests/radiation_damage/coupled_fission_mockup/damage_sub.i
@@ -136,7 +136,6 @@
 [UserObjects]
   [./neutronics_fission_generator]
     type = PKAFissionFragmentNeutronics
-    relative_density = 1
     partial_reaction_rates = '2.0e-11 0 0'
   [../]
   [./rasterizer]


### PR DESCRIPTION
A fix for a MOOSE PR https://github.com/idaholab/moose/pull/12773. That PR allows a wrapped transient run with `FullSolveMultiApp` to reenter properly. I saw with that PR, MyTRIM gets executed twice instead of once before. I think this is the right behavior but need you to confirm. Tag @snschune and @dschwen .

I did not see MOOSE submodule in magpie, so cannot do a submodule update along this PR. For the same reason, I marked this PR as WIP. I will remove WIP after the PR in MOOSE gets merged. Thanks.