### PR TITLE
Compatability with MOOSE after AD 2.0

### DIFF
--- a/include/other/MyTRIMElementEnergyAccess.h
+++ b/include/other/MyTRIMElementEnergyAccess.h
@@ -33,7 +33,7 @@ private:
 
 template <class T>
 MyTRIMElementEnergyAccess<T>::MyTRIMElementEnergyAccess(const InputParameters & parameters)
-  : T(parameters), _mytrim(getUserObject<MyTRIMElementRun>("runner"))
+  : T(parameters), _mytrim(this->template getUserObject<MyTRIMElementRun>("runner"))
 {
   if (this->isNodal())
     mooseError("MyTRIMElementEnergyAccess needs to be applied to an elemental AuxVariable.");

--- a/include/other/MyTRIMElementResultAccess.h
+++ b/include/other/MyTRIMElementResultAccess.h
@@ -39,10 +39,11 @@ private:
 template <class T>
 MyTRIMElementResultAccess<T>::MyTRIMElementResultAccess(const InputParameters & parameters)
   : T(parameters),
-    _mytrim(getUserObject<MyTRIMElementRun>("runner")),
+    _mytrim(this->template getUserObject<MyTRIMElementRun>("runner")),
     _rasterizer(_mytrim.rasterizer()),
-    _ivar(getParam<unsigned int>("ivar")),
-    _defect(getParam<MooseEnum>("defect").template getEnum<ThreadedRecoilLoopBase::DefectType>())
+    _ivar(this->template getParam<unsigned int>("ivar")),
+    _defect(this->template getParam<MooseEnum>("defect")
+                .template getEnum<ThreadedRecoilLoopBase::DefectType>())
 {
   if (this->isNodal())
     mooseError("MyTRIMElementResultAccess needs to be applied to an elemental AuxVariable.");

--- a/src/transfers/MultiAppNeutronicsSpectrumTransfer.C
+++ b/src/transfers/MultiAppNeutronicsSpectrumTransfer.C
@@ -44,7 +44,7 @@ MultiAppNeutronicsSpectrumTransfer::execute()
   // get the neutronics PDF user object
   FEProblemBase & from_problem = _multi_app->problemBase();
   const NeutronicsSpectrumSamplerBase & neutronics_pdf =
-      from_problem.getUserObjectTempl<NeutronicsSpectrumSamplerBase>(_neutronics_pdf_name);
+      from_problem.getUserObject<NeutronicsSpectrumSamplerBase>(_neutronics_pdf_name);
 
   // loop over all sub apps and copy over the neutronics data
   for (unsigned int i = 0; i < _multi_app->numGlobalApps(); ++i)
@@ -57,8 +57,8 @@ MultiAppNeutronicsSpectrumTransfer::execute()
       for (THREAD_ID tid = 0; tid < libMesh::n_threads(); ++tid)
       {
         PKAGeneratorNeutronicsBase & pka_uo = const_cast<PKAGeneratorNeutronicsBase &>(
-            _multi_app->appProblem(i).getUserObjectTempl<PKAGeneratorNeutronicsBase>(
-                _pka_generator_name, tid));
+            _multi_app->appProblem(i).getUserObject<PKAGeneratorNeutronicsBase>(_pka_generator_name,
+                                                                                tid));
         pka_uo.setPDF(zaids, energies, probabilities);
       }
     }

--- a/src/utils/DiscretePKAPDF.C
+++ b/src/utils/DiscretePKAPDF.C
@@ -11,6 +11,8 @@
 #include "MooseRandom.h"
 #include "MagpieUtils.h"
 
+#include "libmesh/vector_value.h"
+
 DiscretePKAPDF::DiscretePKAPDF()
   : DiscretePKAPDFBase(),
     _probability_density_function(MultiIndex<Real>({1})),


### PR DESCRIPTION
There's no (or maybe much less) need for `get*` macros in MOOSE anymore with templating of AD objects removed. Hence a lot of the `get*` names have been added back as a regular method, replacing their corresponding `get*Templ` methods.

The MOOSE submodule hash currently points to a branch head so do not merge. I will update the hash after https://github.com/idaholab/moose/pull/14701 is merged.