### PR TITLE
Bad fix (all 32bit) but easier than consistent 64bit

### DIFF
--- a/src/userobjects/SPPARKSUserObject.C
+++ b/src/userobjects/SPPARKSUserObject.C
@@ -514,7 +514,7 @@ SPPARKSUserObject::initialSetup()
       std::accumulate(&num_fem_nodes[0], &num_fem_nodes[0] + num_fem_nodes.size(), 0);
   const unsigned int num_spparks_nodes_total =
       std::accumulate(&num_spparks_nodes[0], &num_spparks_nodes[0] + num_spparks_nodes.size(), 0);
-  std::vector<libMesh::dof_id_type> remote_fem_nodes(num_fem_nodes_total);
+  std::vector<unsigned int> remote_fem_nodes(num_fem_nodes_total);
   std::vector<Real> remote_fem_coords(num_fem_nodes_total * 3);
   std::vector<unsigned int> remote_spparks_nodes(num_spparks_nodes_total);
   std::vector<Real> remote_spparks_coords(num_spparks_nodes_total * 3);
@@ -564,7 +564,7 @@ SPPARKSUserObject::initialSetup()
   }
 
   // Prepare vectors of MOOSE FEM ids, coordinates
-  std::vector<libMesh::dof_id_type> fem_ids(_num_local_fem_nodes);
+  std::vector<unsigned int> fem_ids(_num_local_fem_nodes);
   std::vector<Real> fem_coords(3 * _num_local_fem_nodes);
   offset = 0;
   for (auto & id : fem_id)


### PR DESCRIPTION
A better fix would be to use MOOSE helpers for the communication or choosing the right MPI datatype depending whether `dof_id_type` is 64 or 32 bits wide. But if this is the issue the bad fix in this PR should make the tests pass. 

Closes #454