### PR TITLE
Only active elements should update communication list

### DIFF
--- a/src/userobjects/RadialGreensConvolution.C
+++ b/src/userobjects/RadialGreensConvolution.C
@@ -368,7 +368,7 @@ RadialGreensConvolution::insertNotLocalPointNeighbors(dof_id_type node)
   mooseAssert(!_nodes_to_elem_map[node].empty(), "Node not found in _nodes_to_elem_map");
 
   for (const auto * elem : _nodes_to_elem_map[node])
-    if (elem->processor_id() != _my_pid)
+    if (elem->processor_id() != _my_pid && elem->active())
       _point_neighbors.insert(elem);
 }
 
@@ -380,7 +380,7 @@ RadialGreensConvolution::insertNotLocalPeriodicPointNeighbors(dof_id_type node,
 
   const Node * first = _mesh.nodePtr(node);
   for (const auto * elem : _nodes_to_elem_map[node])
-    if (elem->processor_id() != _my_pid)
+    if (elem->processor_id() != _my_pid && elem->active())
       _periodic_point_neighbors.emplace(elem, first, reference);
 }
 


### PR DESCRIPTION
This fixes the communication list update by only allowing active ghost elements to update the list. This problem only occurs when refining with AMR.
Closes #477 