### PR TITLE
Added new moose 'use_shell = true' parameter to tests that needed it.

### DIFF
--- a/tests/meshes/tests
+++ b/tests/meshes/tests
@@ -33,6 +33,7 @@
   [./point_locator_copy_gold]
     type = RunCommand
     command = 'mkdir -p gold; mv cascade_quad_out.e gold'
+    use_shell = true
     prereq = point_locator_prepare
   [../]
   # run the same cadcade with the custom point locator
@@ -56,6 +57,7 @@
   [./point_locator_copy_gold_amr]
     type = RunCommand
     command = 'mkdir -p gold; mv cascade_amr_out.e gold'
+    use_shell = true
     prereq = point_locator_prepare_amr
   [../]
   # run the same cadcade with the custom point locator
@@ -85,6 +87,7 @@
   [./point_locator_copy_gold_3d]
     type = RunCommand
     command = 'mkdir -p gold; mv cascade_3d_out.e gold'
+    use_shell = true
     prereq = point_locator_prepare_3d
   [../]
   # run the same cadcade with the custom point locator


### PR DESCRIPTION
As of MOOSE PR #[25773](https://github.com/idaholab/moose/pull/25773), the TestHarness no longer submits tests using the shell by default. This affects tests that use any sort of bash commands, wildcards expansions, ect. However, the shell may be turned on for tests that require it by setting the newly added parameter use_shell = true to each test. This parameter needs to be set for Magpie tests the require use of the shell.

Closes #493.

NOTE: This PR will not pass tests until MOOSE PR #25773 has been merged.