### PR TITLE
Remove HTML-style comments

### DIFF
--- a/doc/content/source/auxkernels/AtomicDensityAux.md
+++ b/doc/content/source/auxkernels/AtomicDensityAux.md
@@ -1,18 +1,23 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # AtomicDensityAux
 
 !alert construction title=Undocumented Class
-The AtomicDensityAux has not been documented. The content contained on this page includes the
-typical automatic documentation associated with a MooseObject; however, what is contained is
-ultimately determined by what is necessary to make the documentation clear for users.
+The AtomicDensityAux has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
 
 !syntax description /AuxKernels/AtomicDensityAux
+
+## Overview
+
+!! Replace these lines with information regarding the AtomicDensityAux object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the AtomicDensityAux object.
 
 !syntax parameters /AuxKernels/AtomicDensityAux
 
 !syntax inputs /AuxKernels/AtomicDensityAux
 
 !syntax children /AuxKernels/AtomicDensityAux
-
-!bibtex bibliography

--- a/doc/content/source/auxkernels/MyTRIMDensityAux.md
+++ b/doc/content/source/auxkernels/MyTRIMDensityAux.md
@@ -1,18 +1,23 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # MyTRIMDensityAux
 
 !alert construction title=Undocumented Class
-The MyTRIMDensityAux has not been documented. The content contained on this page includes the
-typical automatic documentation associated with a MooseObject; however, what is contained is
-ultimately determined by what is necessary to make the documentation clear for users.
+The MyTRIMDensityAux has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
 
 !syntax description /AuxKernels/MyTRIMDensityAux
+
+## Overview
+
+!! Replace these lines with information regarding the MyTRIMDensityAux object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the MyTRIMDensityAux object.
 
 !syntax parameters /AuxKernels/MyTRIMDensityAux
 
 !syntax inputs /AuxKernels/MyTRIMDensityAux
 
 !syntax children /AuxKernels/MyTRIMDensityAux
-
-!bibtex bibliography

--- a/doc/content/source/auxkernels/MyTRIMElementEnergyAux.md
+++ b/doc/content/source/auxkernels/MyTRIMElementEnergyAux.md
@@ -1,18 +1,23 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # MyTRIMElementEnergyAux
 
 !alert construction title=Undocumented Class
-The MyTRIMElementEnergyAux has not been documented. The content contained on this page includes the
-typical automatic documentation associated with a MooseObject; however, what is contained is
-ultimately determined by what is necessary to make the documentation clear for users.
+The MyTRIMElementEnergyAux has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
 
 !syntax description /AuxKernels/MyTRIMElementEnergyAux
+
+## Overview
+
+!! Replace these lines with information regarding the MyTRIMElementEnergyAux object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the MyTRIMElementEnergyAux object.
 
 !syntax parameters /AuxKernels/MyTRIMElementEnergyAux
 
 !syntax inputs /AuxKernels/MyTRIMElementEnergyAux
 
 !syntax children /AuxKernels/MyTRIMElementEnergyAux
-
-!bibtex bibliography

--- a/doc/content/source/auxkernels/MyTRIMElementResultAux.md
+++ b/doc/content/source/auxkernels/MyTRIMElementResultAux.md
@@ -1,18 +1,23 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # MyTRIMElementResultAux
 
 !alert construction title=Undocumented Class
-The MyTRIMElementResultAux has not been documented. The content contained on this page includes the
-typical automatic documentation associated with a MooseObject; however, what is contained is
-ultimately determined by what is necessary to make the documentation clear for users.
+The MyTRIMElementResultAux has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
 
 !syntax description /AuxKernels/MyTRIMElementResultAux
+
+## Overview
+
+!! Replace these lines with information regarding the MyTRIMElementResultAux object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the MyTRIMElementResultAux object.
 
 !syntax parameters /AuxKernels/MyTRIMElementResultAux
 
 !syntax inputs /AuxKernels/MyTRIMElementResultAux
 
 !syntax children /AuxKernels/MyTRIMElementResultAux
-
-!bibtex bibliography

--- a/doc/content/source/auxkernels/SPPARKSAux.md
+++ b/doc/content/source/auxkernels/SPPARKSAux.md
@@ -1,18 +1,23 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # SPPARKSAux
 
 !alert construction title=Undocumented Class
-The SPPARKSAux has not been documented. The content contained on this page includes the
-typical automatic documentation associated with a MooseObject; however, what is contained is
-ultimately determined by what is necessary to make the documentation clear for users.
+The SPPARKSAux has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
 
 !syntax description /AuxKernels/SPPARKSAux
+
+## Overview
+
+!! Replace these lines with information regarding the SPPARKSAux object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the SPPARKSAux object.
 
 !syntax parameters /AuxKernels/SPPARKSAux
 
 !syntax inputs /AuxKernels/SPPARKSAux
 
 !syntax children /AuxKernels/SPPARKSAux
-
-!bibtex bibliography

--- a/doc/content/source/dirackernels/MyTRIMDiracSource.md
+++ b/doc/content/source/dirackernels/MyTRIMDiracSource.md
@@ -1,18 +1,23 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # MyTRIMDiracSource
 
 !alert construction title=Undocumented Class
-The MyTRIMDiracSource has not been documented. The content contained on this page includes the
-typical automatic documentation associated with a MooseObject; however, what is contained is
-ultimately determined by what is necessary to make the documentation clear for users.
+The MyTRIMDiracSource has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
 
 !syntax description /DiracKernels/MyTRIMDiracSource
+
+## Overview
+
+!! Replace these lines with information regarding the MyTRIMDiracSource object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the MyTRIMDiracSource object.
 
 !syntax parameters /DiracKernels/MyTRIMDiracSource
 
 !syntax inputs /DiracKernels/MyTRIMDiracSource
 
 !syntax children /DiracKernels/MyTRIMDiracSource
-
-!bibtex bibliography

--- a/doc/content/source/executioners/SpectralExecutionerLinearElastic.md
+++ b/doc/content/source/executioners/SpectralExecutionerLinearElastic.md
@@ -1,0 +1,23 @@
+# SpectralExecutionerLinearElastic
+
+!alert construction title=Undocumented Class
+The SpectralExecutionerLinearElastic has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Executioner/SpectralExecutionerLinearElastic
+
+## Overview
+
+!! Replace these lines with information regarding the SpectralExecutionerLinearElastic object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the SpectralExecutionerLinearElastic object.
+
+!syntax parameters /Executioner/SpectralExecutionerLinearElastic
+
+!syntax inputs /Executioner/SpectralExecutionerLinearElastic
+
+!syntax children /Executioner/SpectralExecutionerLinearElastic

--- a/doc/content/source/ics/PolarPFMInterfaceIC.md
+++ b/doc/content/source/ics/PolarPFMInterfaceIC.md
@@ -1,0 +1,23 @@
+# PolarPFMInterfaceIC
+
+!alert construction title=Undocumented Class
+The PolarPFMInterfaceIC has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /ICs/PolarPFMInterfaceIC
+
+## Overview
+
+!! Replace these lines with information regarding the PolarPFMInterfaceIC object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the PolarPFMInterfaceIC object.
+
+!syntax parameters /ICs/PolarPFMInterfaceIC
+
+!syntax inputs /ICs/PolarPFMInterfaceIC
+
+!syntax children /ICs/PolarPFMInterfaceIC

--- a/doc/content/source/kernels/CoupledDefectAnnihilation.md
+++ b/doc/content/source/kernels/CoupledDefectAnnihilation.md
@@ -1,18 +1,23 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # CoupledDefectAnnihilation
 
 !alert construction title=Undocumented Class
-The CoupledDefectAnnihilation has not been documented. The content contained on this page includes the
-typical automatic documentation associated with a MooseObject; however, what is contained is
-ultimately determined by what is necessary to make the documentation clear for users.
+The CoupledDefectAnnihilation has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
 
 !syntax description /Kernels/CoupledDefectAnnihilation
+
+## Overview
+
+!! Replace these lines with information regarding the CoupledDefectAnnihilation object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the CoupledDefectAnnihilation object.
 
 !syntax parameters /Kernels/CoupledDefectAnnihilation
 
 !syntax inputs /Kernels/CoupledDefectAnnihilation
 
 !syntax children /Kernels/CoupledDefectAnnihilation
-
-!bibtex bibliography

--- a/doc/content/source/kernels/DefectAnnihilation.md
+++ b/doc/content/source/kernels/DefectAnnihilation.md
@@ -1,18 +1,23 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # DefectAnnihilation
 
 !alert construction title=Undocumented Class
-The DefectAnnihilation has not been documented. The content contained on this page includes the
-typical automatic documentation associated with a MooseObject; however, what is contained is
-ultimately determined by what is necessary to make the documentation clear for users.
+The DefectAnnihilation has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
 
 !syntax description /Kernels/DefectAnnihilation
+
+## Overview
+
+!! Replace these lines with information regarding the DefectAnnihilation object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the DefectAnnihilation object.
 
 !syntax parameters /Kernels/DefectAnnihilation
 
 !syntax inputs /Kernels/DefectAnnihilation
 
 !syntax children /Kernels/DefectAnnihilation
-
-!bibtex bibliography

--- a/doc/content/source/kernels/MyTRIMElementHeatSource.md
+++ b/doc/content/source/kernels/MyTRIMElementHeatSource.md
@@ -1,18 +1,23 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # MyTRIMElementHeatSource
 
 !alert construction title=Undocumented Class
-The MyTRIMElementHeatSource has not been documented. The content contained on this page includes the
-typical automatic documentation associated with a MooseObject; however, what is contained is
-ultimately determined by what is necessary to make the documentation clear for users.
+The MyTRIMElementHeatSource has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
 
 !syntax description /Kernels/MyTRIMElementHeatSource
+
+## Overview
+
+!! Replace these lines with information regarding the MyTRIMElementHeatSource object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the MyTRIMElementHeatSource object.
 
 !syntax parameters /Kernels/MyTRIMElementHeatSource
 
 !syntax inputs /Kernels/MyTRIMElementHeatSource
 
 !syntax children /Kernels/MyTRIMElementHeatSource
-
-!bibtex bibliography

--- a/doc/content/source/kernels/MyTRIMElementSource.md
+++ b/doc/content/source/kernels/MyTRIMElementSource.md
@@ -1,18 +1,23 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # MyTRIMElementSource
 
 !alert construction title=Undocumented Class
-The MyTRIMElementSource has not been documented. The content contained on this page includes the
-typical automatic documentation associated with a MooseObject; however, what is contained is
-ultimately determined by what is necessary to make the documentation clear for users.
+The MyTRIMElementSource has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
 
 !syntax description /Kernels/MyTRIMElementSource
+
+## Overview
+
+!! Replace these lines with information regarding the MyTRIMElementSource object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the MyTRIMElementSource object.
 
 !syntax parameters /Kernels/MyTRIMElementSource
 
 !syntax inputs /Kernels/MyTRIMElementSource
 
 !syntax children /Kernels/MyTRIMElementSource
-
-!bibtex bibliography

--- a/doc/content/source/postprocessors/IsotopeRecoilRate.md
+++ b/doc/content/source/postprocessors/IsotopeRecoilRate.md
@@ -1,18 +1,23 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # IsotopeRecoilRate
 
 !alert construction title=Undocumented Class
-The IsotopeRecoilRate has not been documented. The content contained on this page includes the
-typical automatic documentation associated with a MooseObject; however, what is contained is
-ultimately determined by what is necessary to make the documentation clear for users.
+The IsotopeRecoilRate has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
 
 !syntax description /Postprocessors/IsotopeRecoilRate
+
+## Overview
+
+!! Replace these lines with information regarding the IsotopeRecoilRate object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the IsotopeRecoilRate object.
 
 !syntax parameters /Postprocessors/IsotopeRecoilRate
 
 !syntax inputs /Postprocessors/IsotopeRecoilRate
 
 !syntax children /Postprocessors/IsotopeRecoilRate
-
-!bibtex bibliography

--- a/doc/content/source/postprocessors/MyTRIMPKAInConeInfo.md
+++ b/doc/content/source/postprocessors/MyTRIMPKAInConeInfo.md
@@ -1,18 +1,23 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # MyTRIMPKAInConeInfo
 
 !alert construction title=Undocumented Class
-The MyTRIMPKAInConeInfo has not been documented. The content contained on this page includes the
-typical automatic documentation associated with a MooseObject; however, what is contained is
-ultimately determined by what is necessary to make the documentation clear for users.
+The MyTRIMPKAInConeInfo has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
 
 !syntax description /Postprocessors/MyTRIMPKAInConeInfo
+
+## Overview
+
+!! Replace these lines with information regarding the MyTRIMPKAInConeInfo object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the MyTRIMPKAInConeInfo object.
 
 !syntax parameters /Postprocessors/MyTRIMPKAInConeInfo
 
 !syntax inputs /Postprocessors/MyTRIMPKAInConeInfo
 
 !syntax children /Postprocessors/MyTRIMPKAInConeInfo
-
-!bibtex bibliography

--- a/doc/content/source/postprocessors/MyTRIMPKAInfo.md
+++ b/doc/content/source/postprocessors/MyTRIMPKAInfo.md
@@ -1,18 +1,23 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # MyTRIMPKAInfo
 
 !alert construction title=Undocumented Class
-The MyTRIMPKAInfo has not been documented. The content contained on this page includes the
-typical automatic documentation associated with a MooseObject; however, what is contained is
-ultimately determined by what is necessary to make the documentation clear for users.
+The MyTRIMPKAInfo has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
 
 !syntax description /Postprocessors/MyTRIMPKAInfo
+
+## Overview
+
+!! Replace these lines with information regarding the MyTRIMPKAInfo object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the MyTRIMPKAInfo object.
 
 !syntax parameters /Postprocessors/MyTRIMPKAInfo
 
 !syntax inputs /Postprocessors/MyTRIMPKAInfo
 
 !syntax children /Postprocessors/MyTRIMPKAInfo
-
-!bibtex bibliography

--- a/doc/content/source/transfers/MultiAppNeutronicsSpectrumTransfer.md
+++ b/doc/content/source/transfers/MultiAppNeutronicsSpectrumTransfer.md
@@ -1,18 +1,23 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # MultiAppNeutronicsSpectrumTransfer
 
 !alert construction title=Undocumented Class
-The MultiAppNeutronicsSpectrumTransfer has not been documented. The content contained on this page includes the
-typical automatic documentation associated with a MooseObject; however, what is contained is
-ultimately determined by what is necessary to make the documentation clear for users.
+The MultiAppNeutronicsSpectrumTransfer has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
 
 !syntax description /Transfers/MultiAppNeutronicsSpectrumTransfer
+
+## Overview
+
+!! Replace these lines with information regarding the MultiAppNeutronicsSpectrumTransfer object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the MultiAppNeutronicsSpectrumTransfer object.
 
 !syntax parameters /Transfers/MultiAppNeutronicsSpectrumTransfer
 
 !syntax inputs /Transfers/MultiAppNeutronicsSpectrumTransfer
 
 !syntax children /Transfers/MultiAppNeutronicsSpectrumTransfer
-
-!bibtex bibliography

--- a/doc/content/source/userobjects/ElasticRecoil.md
+++ b/doc/content/source/userobjects/ElasticRecoil.md
@@ -1,18 +1,23 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # ElasticRecoil
 
 !alert construction title=Undocumented Class
-The ElasticRecoil has not been documented. The content contained on this page includes the
-+typical automatic documentation associated with a MooseObject; however, what is contained is
-+ultimately determined by what is necessary to make the documentation clear for users.
+The ElasticRecoil has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
 
 !syntax description /UserObjects/ElasticRecoil
+
+## Overview
+
+!! Replace these lines with information regarding the ElasticRecoil object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ElasticRecoil object.
 
 !syntax parameters /UserObjects/ElasticRecoil
 
 !syntax inputs /UserObjects/ElasticRecoil
 
 !syntax children /UserObjects/ElasticRecoil
-
-!bibtex bibliography

--- a/doc/content/source/userobjects/InelasticRecoil.md
+++ b/doc/content/source/userobjects/InelasticRecoil.md
@@ -1,18 +1,23 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # InelasticRecoil
 
 !alert construction title=Undocumented Class
-The InelasticRecoil has not been documented. The content contained on this page includes the
-+typical automatic documentation associated with a MooseObject; however, what is contained is
-+ultimately determined by what is necessary to make the documentation clear for users.
+The InelasticRecoil has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
 
 !syntax description /UserObjects/InelasticRecoil
+
+## Overview
+
+!! Replace these lines with information regarding the InelasticRecoil object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the InelasticRecoil object.
 
 !syntax parameters /UserObjects/InelasticRecoil
 
 !syntax inputs /UserObjects/InelasticRecoil
 
 !syntax children /UserObjects/InelasticRecoil
-
-!bibtex bibliography

--- a/doc/content/source/userobjects/MyTRIMDiracRun.md
+++ b/doc/content/source/userobjects/MyTRIMDiracRun.md
@@ -1,18 +1,23 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # MyTRIMDiracRun
 
 !alert construction title=Undocumented Class
-The MyTRIMDiracRun has not been documented. The content contained on this page includes the
-typical automatic documentation associated with a MooseObject; however, what is contained is
-ultimately determined by what is necessary to make the documentation clear for users.
+The MyTRIMDiracRun has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
 
 !syntax description /UserObjects/MyTRIMDiracRun
+
+## Overview
+
+!! Replace these lines with information regarding the MyTRIMDiracRun object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the MyTRIMDiracRun object.
 
 !syntax parameters /UserObjects/MyTRIMDiracRun
 
 !syntax inputs /UserObjects/MyTRIMDiracRun
 
 !syntax children /UserObjects/MyTRIMDiracRun
-
-!bibtex bibliography

--- a/doc/content/source/userobjects/MyTRIMElementRun.md
+++ b/doc/content/source/userobjects/MyTRIMElementRun.md
@@ -1,18 +1,23 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # MyTRIMElementRun
 
 !alert construction title=Undocumented Class
-The MyTRIMElementRun has not been documented. The content contained on this page includes the
-typical automatic documentation associated with a MooseObject; however, what is contained is
-ultimately determined by what is necessary to make the documentation clear for users.
+The MyTRIMElementRun has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
 
 !syntax description /UserObjects/MyTRIMElementRun
+
+## Overview
+
+!! Replace these lines with information regarding the MyTRIMElementRun object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the MyTRIMElementRun object.
 
 !syntax parameters /UserObjects/MyTRIMElementRun
 
 !syntax inputs /UserObjects/MyTRIMElementRun
 
 !syntax children /UserObjects/MyTRIMElementRun
-
-!bibtex bibliography

--- a/doc/content/source/userobjects/NeutronicsSpectrumSamplerFission.md
+++ b/doc/content/source/userobjects/NeutronicsSpectrumSamplerFission.md
@@ -1,18 +1,23 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # NeutronicsSpectrumSamplerFission
 
 !alert construction title=Undocumented Class
-The NeutronicsSpectrumSamplerFission has not been documented. The content contained on this page includes the
-typical automatic documentation associated with a MooseObject; however, what is contained is
-ultimately determined by what is necessary to make the documentation clear for users.
+The NeutronicsSpectrumSamplerFission has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
 
 !syntax description /UserObjects/NeutronicsSpectrumSamplerFission
+
+## Overview
+
+!! Replace these lines with information regarding the NeutronicsSpectrumSamplerFission object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the NeutronicsSpectrumSamplerFission object.
 
 !syntax parameters /UserObjects/NeutronicsSpectrumSamplerFission
 
 !syntax inputs /UserObjects/NeutronicsSpectrumSamplerFission
 
 !syntax children /UserObjects/NeutronicsSpectrumSamplerFission
-
-!bibtex bibliography

--- a/doc/content/source/userobjects/SPPARKSUserObject.md
+++ b/doc/content/source/userobjects/SPPARKSUserObject.md
@@ -1,18 +1,23 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # SPPARKSUserObject
 
 !alert construction title=Undocumented Class
-The SPPARKSUserObject has not been documented. The content contained on this page includes the
-typical automatic documentation associated with a MooseObject; however, what is contained is
-ultimately determined by what is necessary to make the documentation clear for users.
+The SPPARKSUserObject has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
 
 !syntax description /UserObjects/SPPARKSUserObject
+
+## Overview
+
+!! Replace these lines with information regarding the SPPARKSUserObject object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the SPPARKSUserObject object.
 
 !syntax parameters /UserObjects/SPPARKSUserObject
 
 !syntax inputs /UserObjects/SPPARKSUserObject
 
 !syntax children /UserObjects/SPPARKSUserObject
-
-!bibtex bibliography

--- a/doc/content/source/vectorpostprocessors/IsotopeRecoilRateSampler.md
+++ b/doc/content/source/vectorpostprocessors/IsotopeRecoilRateSampler.md
@@ -1,18 +1,23 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # IsotopeRecoilRateSampler
 
 !alert construction title=Undocumented Class
-The IsotopeRecoilRateSampler has not been documented. The content contained on this page includes the
-typical automatic documentation associated with a MooseObject; however, what is contained is
-ultimately determined by what is necessary to make the documentation clear for users.
+The IsotopeRecoilRateSampler has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
 
 !syntax description /VectorPostprocessors/IsotopeRecoilRateSampler
+
+## Overview
+
+!! Replace these lines with information regarding the IsotopeRecoilRateSampler object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the IsotopeRecoilRateSampler object.
 
 !syntax parameters /VectorPostprocessors/IsotopeRecoilRateSampler
 
 !syntax inputs /VectorPostprocessors/IsotopeRecoilRateSampler
 
 !syntax children /VectorPostprocessors/IsotopeRecoilRateSampler
-
-!bibtex bibliography

--- a/doc/content/source/vectorpostprocessors/MyTRIMDiracEnergyResult.md
+++ b/doc/content/source/vectorpostprocessors/MyTRIMDiracEnergyResult.md
@@ -1,0 +1,23 @@
+# MyTRIMDiracEnergyResult
+
+!alert construction title=Undocumented Class
+The MyTRIMDiracEnergyResult has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /VectorPostprocessors/MyTRIMDiracEnergyResult
+
+## Overview
+
+!! Replace these lines with information regarding the MyTRIMDiracEnergyResult object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the MyTRIMDiracEnergyResult object.
+
+!syntax parameters /VectorPostprocessors/MyTRIMDiracEnergyResult
+
+!syntax inputs /VectorPostprocessors/MyTRIMDiracEnergyResult
+
+!syntax children /VectorPostprocessors/MyTRIMDiracEnergyResult

--- a/doc/content/source/vectorpostprocessors/MyTRIMDiracResult.md
+++ b/doc/content/source/vectorpostprocessors/MyTRIMDiracResult.md
@@ -1,18 +1,23 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # MyTRIMDiracResult
 
 !alert construction title=Undocumented Class
-The MyTRIMDiracResult has not been documented. The content contained on this page includes the
-typical automatic documentation associated with a MooseObject; however, what is contained is
-ultimately determined by what is necessary to make the documentation clear for users.
+The MyTRIMDiracResult has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
 
 !syntax description /VectorPostprocessors/MyTRIMDiracResult
+
+## Overview
+
+!! Replace these lines with information regarding the MyTRIMDiracResult object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the MyTRIMDiracResult object.
 
 !syntax parameters /VectorPostprocessors/MyTRIMDiracResult
 
 !syntax inputs /VectorPostprocessors/MyTRIMDiracResult
 
 !syntax children /VectorPostprocessors/MyTRIMDiracResult
-
-!bibtex bibliography

--- a/doc/content/source/vectorpostprocessors/MyTRIMPKAEnergyHistogram.md
+++ b/doc/content/source/vectorpostprocessors/MyTRIMPKAEnergyHistogram.md
@@ -1,18 +1,23 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # MyTRIMPKAEnergyHistogram
 
 !alert construction title=Undocumented Class
-The MyTRIMPKAEnergyHistogram has not been documented. The content contained on this page includes the
-typical automatic documentation associated with a MooseObject; however, what is contained is
-ultimately determined by what is necessary to make the documentation clear for users.
+The MyTRIMPKAEnergyHistogram has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
 
 !syntax description /VectorPostprocessors/MyTRIMPKAEnergyHistogram
+
+## Overview
+
+!! Replace these lines with information regarding the MyTRIMPKAEnergyHistogram object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the MyTRIMPKAEnergyHistogram object.
 
 !syntax parameters /VectorPostprocessors/MyTRIMPKAEnergyHistogram
 
 !syntax inputs /VectorPostprocessors/MyTRIMPKAEnergyHistogram
 
 !syntax children /VectorPostprocessors/MyTRIMPKAEnergyHistogram
-
-!bibtex bibliography

--- a/doc/sqa_reports.yml
+++ b/doc/sqa_reports.yml
@@ -1,0 +1,22 @@
+Applications:
+    magpie:
+        app_types:
+            - MagpieApp
+        content_directory: ${ROOT_DIR}/doc/content
+        remove:
+            - ${MOOSE_DIR}/framework/doc/remove.yml
+        log_default: WARNING
+        show_warning: false
+        unregister:
+            - ${MOOSE_DIR}/framework/doc/unregister.yml
+
+Documents:      # Disabled, not required
+    log_default: NONE
+    show_warning: false
+
+Requirements:   # Disabled, not required
+    zapdos:
+        directories:
+            - ${ROOT_DIR}/test
+        log_default: NONE
+        show_warning: false


### PR DESCRIPTION
## Reason
HTML-style comment syntax is being removed in idaholab/moose#29581. All applications that use this syntax should be converted to MooseDocs-style syntax (`!!` for single-line, pair of `!!!` for multi-line). 

## Design
Update all markdown comment syntax. In this case, this requires a minimal SQA configuration so that documentation stubs could be updated.

## Impact
No impact to documentation or user experience.
